### PR TITLE
Add missing email support js in error page

### DIFF
--- a/grails-app/taglib/au/org/ala/collectory/CollectoryTagLib.groovy
+++ b/grails-app/taglib/au/org/ala/collectory/CollectoryTagLib.groovy
@@ -730,7 +730,7 @@ class CollectoryTagLib {
     }
 
     def emailBugLink = { attrs, body ->
-        def strEncodedAtSign = "(SPAM_MAIL@ALA.ORG.AU)"
+        def strEncodedAtSign = "PUT_ONLY_AN_@_SIGN_HERE"
         String email = attrs.email
         if (!email)
             email = body().toString()
@@ -739,7 +739,8 @@ class CollectoryTagLib {
         if (index > 0) {
             email = email.replaceAll("@", strEncodedAtSign)
         }
-        out << "<a href='#' class='link' onclick=\"return sendBugEmail('${email}','${attrs.message}')\">${body()}</a>"
+        def subject = "I found an issue in ${grailsApplication.config.skin.orgNameShort}"
+        out << "<a href='#' class='link' onclick=\"function sendBugEmail(n,o){console.log(n);console.log(o);var e='mailto:'+n+'?subject='+encodeURIComponent('$subject')+'&body='+o; console.log(e); window.location.href=e};return sendBugEmail('${email}','${attrs.message.encodeAsURL().replace("+", "%20")}')\">${body()}</a>"
     }
 
     /**

--- a/grails-app/views/error.gsp
+++ b/grails-app/views/error.gsp
@@ -34,7 +34,9 @@
 		  <p>If this is the first time this page has appeared, <span class="action">try the refresh button in your browser.</span></p>
 		  <p>If this fails, <span class="action">try to return to the <a href="/collectory">home page</a> and start again.</span></p>
 		  <p>If this page is still displayed, <span class="action">please report the incident to ${grailsApplication.config.skin.orgNameShort} support.
-		  <cl:emailBugLink email="${grailsApplication.config.skin.orgSupportEmail}" message="${exception?.message}">Click here to email ${grailsApplication.config.skin.orgNameShort} support</cl:emailBugLink>.</span></p>
+		  <cl:emailBugLink email="${grailsApplication.config.skin.orgSupportEmail}"
+              message="Technical details of the error:\n\nError ${request.'javax.servlet.error.status_code'}: ${request.'javax.servlet.error.message'}\nServlet: ${request.'javax.servlet.error.servlet_name'}\nCaused by: ${exception.cause?.message}\nClass: ${exception.className}\nAt Line: ${exception.lineNumber}\n\nStacktrace: ${exception.stackTraceLines?.toString()}">
+			  Click here to email ${grailsApplication.config.skin.orgNameShort} support</cl:emailBugLink>.</span></p>
 		  <p>The following is useful information that helps us discover what has happened. Please copy it into emails requesting support.</p>
 		  <p>You might also like to expand the more detailed information by clicking on 'Show stack trace' and copying that text to us as well.</p>
 		  <p>Thanks for your patience.</p>


### PR DESCRIPTION
This PR add the missing `sendBugEmail` js function so people can click and send emails to support on errors with some technical info. 

Sample:

![image](https://user-images.githubusercontent.com/180085/161538366-18a891b3-ce95-432b-9f27-20ba2ae8be17.png)

