### PR TITLE
A possible fix for 91

### DIFF
--- a/grails-app/assets/javascripts/images.js
+++ b/grails-app/assets/javascripts/images.js
@@ -4,7 +4,8 @@
 function loadImagesTab() {
     var wsBase = "/occurrences/search.json";
     var uiBase = "/occurrences/search";
-    var imagesQueryUrl = "?facets=type_status&fq=multimedia%3AImage&pageSize=100&q=collectionUid:" + SHOW_REC.instanceUuid;
+
+    var imagesQueryUrl = "?facets=type_status&fq=multimedia%3AImage&pageSize=100&q=" + (SHOW_REC.isPipelinesCompatible? "collectionUid:" : "collection_uid:") + SHOW_REC.instanceUuid;
     $.ajax({
         url: SHOW_REC.biocacheServicesUrl + wsBase + imagesQueryUrl,
         dataType: 'jsonp',

--- a/grails-app/assets/javascripts/images.js
+++ b/grails-app/assets/javascripts/images.js
@@ -4,8 +4,8 @@
 function loadImagesTab() {
     var wsBase = "/occurrences/search.json";
     var uiBase = "/occurrences/search";
-
     var imagesQueryUrl = "?facets=type_status&fq=multimedia%3AImage&pageSize=100&q=" + (SHOW_REC.isPipelinesCompatible? "collectionUid:" : "collection_uid:") + SHOW_REC.instanceUuid;
+
     $.ajax({
         url: SHOW_REC.biocacheServicesUrl + wsBase + imagesQueryUrl,
         dataType: 'jsonp',

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -191,6 +191,7 @@ disableAlertLinks: false
 disableLoggerLinks: false
 biocacheServicesUrl: https://biocache.ala.org.au/ws
 biocacheUiURL: https://biocache.ala.org.au
+isPipelinesCompatible: true
 
 ROLE_ADMIN: 'ROLE_ADMIN'
 

--- a/grails-app/views/public/showCollection.gsp
+++ b/grails-app/views/public/showCollection.gsp
@@ -1,5 +1,6 @@
 <%@ page import="java.text.DecimalFormat; au.org.ala.collectory.Collection; au.org.ala.collectory.Institution" %>
 <g:set var="orgNameLong" value="${grailsApplication.config.skin.orgNameLong}"/>
+<g:set var="isPipelinesCompatible" value="${grailsApplication.config.getProperty("isPipelinesCompatible", Boolean.class)}"/>
 <html>
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
@@ -24,6 +25,7 @@
               biocacheWebappUrl: "${grailsApplication.config.biocacheUiURL}",
               loggerServiceUrl: "${grailsApplication.config.loggerURL}",
               loadLoggerStats: ${!grailsApplication.config.disableLoggerLinks.toBoolean()},
+              isPipelinesCompatible: ${isPipelinesCompatible},
               instanceUuid: "${instance.uid}",
               instanceName:"${instance.name}"
           }
@@ -306,7 +308,7 @@
             }
             loadImagesTab();
         </asset:script>
-        <g:render template="charts" model="[facet:'collectionUid', instance: instance]" />
-        <g:render template="progress" model="[facet:'collection_uid', instance: instance]" />
+        <g:render template="charts" model="[facet: isPipelinesCompatible ? 'collectionUid': 'collection_uid', instance: instance]" />
+        <g:render template="progress" model="[facet: isPipelinesCompatible ? 'collectionUid':'collection_uid', instance: instance]" />
     </body>
 </html>


### PR DESCRIPTION
A possible fix for #91 adding a new variable `isPipelinesCompatible` so we can use `collectory` with `biocache-service` < `3.0.0` also.

Feel free to comment/reject or propose other solution to this issue.