### PR TITLE
Fix for 112

### DIFF
--- a/grails-app/assets/stylesheets/map.css
+++ b/grails-app/assets/stylesheets/map.css
@@ -248,6 +248,7 @@ ul.facets {
 
 .resource-name {
     width: 20em;
+    min-width: 200px;
 }
 
 .resource-mapping {

--- a/grails-app/views/manage/repatriateReview.gsp
+++ b/grails-app/views/manage/repatriateReview.gsp
@@ -11,6 +11,13 @@
     <meta name="layout" content="${grailsApplication.config.skin.layout}" />
     <title><g:message code="manage.extloadr.title" /></title>
     <asset:stylesheet src="application.css"/>
+    <script type="text/javascript">
+      var COLLECTORY_CONF = {
+        contextPath: "${request.contextPath}",
+        locale: "${(org.springframework.web.servlet.support.RequestContextUtils.getLocale(request).toString())?:request.locale}",
+        cartodbPattern: "${grailsApplication.config.cartodb.pattern}"
+      };
+    </script>
     <asset:javascript src="application-pages.js"/>
 </head>
 <body>
@@ -77,9 +84,6 @@
             </tr>
             </g:each>
             </g:if>
-            <g:else>
-                <tr><td colspan="8"><g:message code="manage.extloadr.noresources"/></td></tr>
-            </g:else>
             </tbody>
         </table>
         <div>
@@ -123,12 +127,16 @@
             select: "single"
         });
         resource_table = $('#resource-table').DataTable({
+            "language": {
+               "emptyTable": jQuery.i18n.prop('manage.extloadr.noresources'),
+            },
             "columns": [
                 {"orderable": false},
                 null,
                 null,
                 null,
                 null,
+                {"orderable": false},
                 {"orderable": false},
                 {"orderable": false},
                 {"orderable": false}


### PR DESCRIPTION
Fix for #112.

The main error cause was that the [number of `th` and `td`](https://stackoverflow.com/questions/25377637/datatables-cannot-read-property-mdata-of-undefined) and the configuration didn't matched with different search results.

With this the pagination and related datatable header/footer started to work also:
![image](https://user-images.githubusercontent.com/180085/162732992-791c7207-9660-4c08-8400-5454c25d4012.png)

and with empty results (just configuring the empty table message) without a js error it looks like:

![image](https://user-images.githubusercontent.com/180085/162733157-ea7be0d7-ac79-446b-aa81-a43860d7d4d1.png)

I also configured a `min-width` for the `name` because was quite small:

![image](https://user-images.githubusercontent.com/180085/162733319-bc656e6e-eff3-4b99-b886-ae311ccb55da.png)

and now:

![image](https://user-images.githubusercontent.com/180085/162733552-539a1229-2e09-46ab-a284-a0cf589d0fce.png)

