### PR TITLE
Fix for 135

### DIFF
--- a/grails-app/controllers/au/org/ala/collectory/DataResourceController.groovy
+++ b/grails-app/controllers/au/org/ala/collectory/DataResourceController.groovy
@@ -245,7 +245,7 @@ class DataResourceController extends ProviderGroupController {
         // create new links
         newConsumers.each {
             if (!(it in oldConsumers)) {
-                DataLink.withTransaction {
+                DataLink.withTransaction { status ->
                     def dl = new DataLink(consumer: it, provider: pg.uid).save()
                     auditLog(pg, 'INSERT', 'consumer', '', it, dl)
                     log.info "created link from ${pg.uid} to ${it}"
@@ -255,7 +255,7 @@ class DataResourceController extends ProviderGroupController {
         // remove old links - NOTE only for the variety (collection or institution) that has been returned
         oldConsumers.each {
             if (!(it in newConsumers) && it[0..1] == params.source) {
-                DataLink.withTransaction {
+                DataLink.withTransaction { status ->
                     log.info "deleting link from ${pg.uid} to ${it}"
                     def dl = DataLink.findByConsumerAndProvider(it, pg.uid)
                     auditLog(pg, 'DELETE', 'consumer', it, '', dl)


### PR DESCRIPTION
The `it` variable of the `each` loop is overwritten by the `withTransaction` status, so the `auditLog` and the `save` fails because in fact, it is trying to persist and use the transaction status instead of the `it` string variable of the `each.`

This fix #135.

With this PR we can again associate records consumers:

![image](https://user-images.githubusercontent.com/180085/180417081-ad6a7ae4-5899-4526-86fa-e31eebdb0972.png)

