### PR TITLE
Fix for 145

### DIFF
--- a/grails-app/controllers/au/org/ala/collectory/PublicController.groovy
+++ b/grails-app/controllers/au/org/ala/collectory/PublicController.groovy
@@ -642,6 +642,7 @@ class PublicController {
             projections {
                 groupProperty("institution")
             }
+            institution { order("name") }
         }
 
         results.each {
@@ -653,7 +654,7 @@ class PublicController {
                 def lon = (it.longitude == 0.0) ? -1 : it.longitude
 
                 if (it.collections) {
-
+                    it.collections = it.collections.sort { it.name }
                     def relevantCollections = []
 
                     if (showAll ) {


### PR DESCRIPTION
Fix for #145.

With this PR institutions and collections are sorted by name:

![image](https://user-images.githubusercontent.com/180085/183871387-863931f0-9f72-4853-85ed-0e0ec80d85cd.png)

I did the sort in groovy instead of in javascript like in 
https://github.com/AtlasOfLivingAustralia/collectory-plugin/blob/2ed9737c04db9a07fe9052d40ece43c4e5a2b207/web-app/js/map.js#L525
