### PR TITLE
Fix for 163 and 164

### DIFF
--- a/grails-app/controllers/au/org/ala/collectory/ProviderMapController.groovy
+++ b/grails-app/controllers/au/org/ala/collectory/ProviderMapController.groovy
@@ -42,9 +42,10 @@ class ProviderMapController {
         providerMapInstance.properties = params
         println "createFor = ${params.createFor}"
         if (params.createFor) {
-            def pg = Collection._get(params.createFor) as Collection
+            def pg = Collection.findByUid(params.createFor) as Collection
             if (pg) {
                 providerMapInstance.collection = pg
+                providerMapInstance.institution = pg.institution
             }
         }
         return [providerMapInstance: providerMapInstance, returnTo: params.returnTo]
@@ -125,12 +126,8 @@ class ProviderMapController {
                     // remove collection link
                     providerMapInstance.collection?.providerMap = null
                     // remove code links
-                    providerMapInstance.collectionCodes.each {
-                        providerMapInstance.removeFromCollectionCodes it
-                    }
-                    providerMapInstance.institutionCodes.each {
-                        providerMapInstance.removeFromInstitutionCodes it
-                    }
+                    providerMapInstance.collectionCodes.removeAll(providerMapInstance.collectionCodes)
+                    providerMapInstance.institutionCodes.removeAll(providerMapInstance.institutionCodes)
                     // remove map
                     providerMapInstance.delete(flush: true)
                     flash.message = "${message(code: 'default.deleted.message', args: [message(code: 'providerMap.label', default: 'ProviderMap'), params.id])}"


### PR DESCRIPTION
With this PR, we can remove again provider maps (#164):

![image](https://user-images.githubusercontent.com/180085/193887900-0aab0426-c2c5-47b7-9377-e7739f0a9067.png)

and also create provider maps from its collection (assigning also the institution):

Pressing edit in:

![image](https://user-images.githubusercontent.com/180085/193888185-afc108fa-b853-4fe9-9162-84248b93f731.png)

We get:

![image](https://user-images.githubusercontent.com/180085/193888200-55c713cd-c4fe-4556-847c-31eab8286606.png)

instead of the missing  `_get` exception (#163)