### PR TITLE
updating biocache service api call from deprecated /occurrence to /oc…

### DIFF
--- a/grails-app/assets/javascripts/datasets.js
+++ b/grails-app/assets/javascripts/datasets.js
@@ -90,7 +90,7 @@ function loadResources(serverUrl, biocacheRecordsUrl, biocacheServicesUrl) {
     }
 
     if (COLLECTORY_CONF.showExtraInfoInDataSetsView) {
-        $.getJSON(biocacheServicesUrl + "/occurrence/facets?facets=data_resource_uid&pageSize=0&flimit=-1", function(dataStats) {
+        $.getJSON(biocacheServicesUrl + "/occurrences/facets?facets=data_resource_uid&pageSize=0&flimit=-1", function(dataStats) {
             resourcesStats = dataStats;
             loadResourcesCondensed();
         });

--- a/grails-app/taglib/au/org/ala/collectory/CollectoryTagLib.groovy
+++ b/grails-app/taglib/au/org/ala/collectory/CollectoryTagLib.groovy
@@ -956,7 +956,7 @@ class CollectoryTagLib {
         else {
             queryStr = fieldNameForSearch(uidStr) + ":" + uidStr
         }
-        return  grailsApplication.config.biocacheUiURL + "/occurrence/search?q=" + queryStr
+        return  grailsApplication.config.biocacheUiURL + "/occurrences/search?q=" + queryStr
     }
 
     private String fieldNameForSearch(uid) {


### PR DESCRIPTION
…currences, updating existing bioache ui /occurrence/search to newer /occurrences/search

I noticed that the collectory [datasets](
https://collections-test.ala.org.au/datasets ) page with recent changes is failing to load any data due to a facets request failure when querying from API Gateway.  It is using deprecated `/occurrence/facets` which is not published to api gateway.  

 - Updated `/occurrence/facets` to `/occurrences/facets` 
 - Also updated UI url creation to update `occurrence/search` to newer `/occurrences/search`
