### PR TITLE
Fix for repatriation error #210

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -109,7 +109,7 @@ projectName: Atlas of Living Australia
 regionName: Australia
 uploadFilePath: /data/collectory/upload
 uploadExternalUrlPath: http://localhost/upload
-gbifApiUrl: 'http://api.gbif.org/v1/'
+gbifApiUrl: 'https://api.gbif.org/v1/'
 gbifUniqueKeyTerm: "http://rs.gbif.org/terms/1.0/gbifID"
 
 gbif:

--- a/src/main/groovy/au/org/ala/collectory/resources/gbif/GbifDataSourceAdapter.groovy
+++ b/src/main/groovy/au/org/ala/collectory/resources/gbif/GbifDataSourceAdapter.groovy
@@ -10,10 +10,6 @@ import au.org.ala.collectory.resources.TaskPhase
 import au.org.ala.collectory.GbifService
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
-import io.micronaut.http.HttpRequest
-import io.micronaut.http.HttpResponse
-import io.micronaut.http.client.HttpClient
-import io.reactivex.rxjava3.core.Flowable
 import org.apache.commons.io.FileUtils
 import org.grails.web.json.JSONObject
 import org.slf4j.LoggerFactory
@@ -178,7 +174,7 @@ class GbifDataSourceAdapter extends DataSourceAdapter {
 
     @Override
     Map getDataset(String id) throws ExternalResourceException {
-        JSONObject json = getJSONWS(DATASET_GET.format([id ].toArray()))
+        JSONObject json = getJSONWS(DATASET_GET.format([id ].toArray()), false)
         return json ? translate(json) : null
     }
 
@@ -237,23 +233,30 @@ class GbifDataSourceAdapter extends DataSourceAdapter {
      *
      * @return A JSON response
      */
-    def getJSONWS(String path) throws ExternalResourceException {
+    def getJSONWS(String path, boolean authRequired = true) throws ExternalResourceException {
 
         def url = new URL(configuration.endpoint, path)
-        def httpRequest = HttpRequest.GET(url.toURI())
-        if (configuration.username) {
-            httpRequest.basicAuth(configuration.username, configuration.password)
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection()
+        connection.setRequestMethod("GET")
+
+        // Add HTTP Basic Authentication header
+        if (authRequired) {
+            String authString = "${configuration.username}:${configuration.password}"
+            String encodedAuthString = "Basic " + authString.bytes.encodeBase64().toString()
+            connection.setRequestProperty("Authorization", encodedAuthString)
         }
 
-        HttpClient http = HttpClient.create(url)
-        Flowable<HttpResponse<String>> call = http.exchange(httpRequest, String.class) as Flowable<HttpResponse<String>>
-        HttpResponse<String> response =  call.blockingFirst();
-        Optional<String> message = response.getBody(String.class);
-
-        if (message.isPresent()){
-            new JsonSlurper().parseText(message.get())
+        // Check for a successful response code (200 OK)
+        if (connection.responseCode == HttpURLConnection.HTTP_OK) {
+            def response = new StringBuffer()
+            connection.inputStream.withReader { reader ->
+                response << reader.getText()
+            }
+            // Parse JSON response
+            return new JsonSlurper().parseText(response.toString())
         } else {
-            throw new ExternalResourceException("Unable to get ${http.uri} response ${resp.statusLine}", "manage.note.note10", http.uri, resp.statusLine)
+            // Handle error response (if needed)
+            throw new ExternalResourceException("Unable to get ${url.toString()} response ${connection.responseCode }", "manage.note.note10", url.toString(), connection.responseCode )
         }
     }
 
@@ -266,22 +269,24 @@ class GbifDataSourceAdapter extends DataSourceAdapter {
     @Override
     boolean isDataAvailableForResource(String guid) throws ExternalResourceException {
         def url = new URL(configuration.endpoint, DATASET_RECORD_COUNT.format([guid].toArray()))
-        def httpRequest = HttpRequest.GET(url.toURI())
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection()
+        connection.setRequestMethod("GET")
 
-        if (configuration.username) {
-            httpRequest.basicAuth(configuration.username, configuration.password)
-        }
+        String authString = "${configuration.username}:${configuration.password}"
+        String encodedAuthString = "Basic " + authString.bytes.encodeBase64().toString()
+        connection.setRequestProperty("Authorization", encodedAuthString)
 
-        HttpClient http = HttpClient.create(url)
-        Flowable<HttpResponse<String>> call = http.exchange(httpRequest, String.class)
-        HttpResponse<String> response =  call.blockingFirst();
-        Optional<String> message = response.getBody(String.class);
-
-        if (message.isPresent()){
-            def count = message.get()
-            return count && count.toInteger() > 0
+        // Check for a successful response code (200 OK)
+        if (connection.responseCode == HttpURLConnection.HTTP_OK) {
+            def response = new StringBuffer()
+            connection.inputStream.withReader { reader ->
+                response << reader.getText()
+            }
+            // Parse response
+            return response && response.length() > 0 && response.toInteger() > 0
         } else {
-            throw new ExternalResourceException("Unable check for data", "manage.note.note11", guid, response.getStatus().toString())
+            // Handle error response (if needed)
+            throw new ExternalResourceException("Unable check for data", "manage.note.note11", guid, connection.responseCode)
         }
     }
 

--- a/src/main/groovy/au/org/ala/collectory/resources/gbif/GbifRepatDataSourceAdapter.groovy
+++ b/src/main/groovy/au/org/ala/collectory/resources/gbif/GbifRepatDataSourceAdapter.groovy
@@ -30,7 +30,7 @@ class GbifRepatDataSourceAdapter extends GbifDataSourceAdapter {
 
         LOGGER.info("Requesting dataset lists configuration.country: ${configuration.country}")
         String url = MessageFormat.format(OCCURRENCE_REPAT_SEARCH, configuration.country, configuration.recordType)
-        JSONObject json = getJSONWS(url)
+        JSONObject json = getJSONWS(url, false)
         if (json?.facets) {
             json.facets[0].counts.each {
                 keys << it.name


### PR DESCRIPTION
See #210 
This just removes the usage of the reactor http apis which in favour of the more stable java.net for calls to GBIF.