### PR TITLE
Fix for 116

### DIFF
--- a/grails-app/services/au/org/ala/collectory/DataImportService.groovy
+++ b/grails-app/services/au/org/ala/collectory/DataImportService.groovy
@@ -150,7 +150,8 @@ class DataImportService {
                 if (file.getName().startsWith(EML_FILE)) {
                     //open the XML file that contains the EML details for the GBIF resource
                     def xml = new XmlSlurper().parseText(zipFile.getInputStream(file).getText("UTF-8"))
-                    contacts = emlImportService.extractContactsFromEml(xml, dataResource)
+                    def result = emlImportService.extractContactsFromEml(xml, dataResource)
+                    contacts = result.contacts
                 }
             }
         }

--- a/grails-app/services/au/org/ala/collectory/EmlImportService.groovy
+++ b/grails-app/services/au/org/ala/collectory/EmlImportService.groovy
@@ -187,6 +187,8 @@ class EmlImportService {
 
         if (!contact && (hasEmail || hasName)) {
             contact = new Contact()
+        } else {
+            return null
         }
 
         // Update the contact details

--- a/grails-app/services/au/org/ala/collectory/EmlImportService.groovy
+++ b/grails-app/services/au/org/ala/collectory/EmlImportService.groovy
@@ -115,6 +115,7 @@ class EmlImportService {
     def extractContactsFromEml(eml, dataResource){
 
         def contacts = []
+        def primaryContacts = []
 
         emlFields.each { name, accessor ->
             def val = accessor(eml)
@@ -126,7 +127,7 @@ class EmlImportService {
         //add contacts...
         if (eml.dataset.creator){
             eml.dataset.creator.each {
-                def contact = addContact(it)
+                def contact = addOrUpdateContact(it)
                 if (contact){
                     contacts << contact
                 }
@@ -137,7 +138,7 @@ class EmlImportService {
                 && eml.dataset.metadataProvider.electronicMailAddress != eml.dataset.creator.electronicMailAddress){
 
             eml.dataset.metadataProvider.each {
-                def contact = addContact(it)
+                def contact = addOrUpdateContact(it)
                 if (contact){
                     contacts << contact
                 }
@@ -147,26 +148,27 @@ class EmlImportService {
         // Add additional contacts
         if (eml.dataset.contact){
             eml.dataset.contact.each {
-                def contact = addContact(it)
+                def contact = addOrUpdateContact(it)
                 if (contact){
                     contacts << contact
+                    primaryContacts << contact
                 }
             }
         }
 
         if (eml.dataset.associatedParty){
             eml.dataset.associatedParty.each {
-                def contact = addContact(it)
+                def contact = addOrUpdateContact(it)
                 if (contact){
                     contacts << contact
                 }
             }
         }
 
-        contacts
+        [contacts: contacts, primaryContacts: primaryContacts]
     }
 
-    private def addContact(emlElement) {
+    private def addOrUpdateContact(emlElement) {
         def contact = null
         if (emlElement.electronicMailAddress && !emlElement.electronicMailAddress.isEmpty()) {
             String email = emlElement.electronicMailAddress.text().trim()
@@ -185,23 +187,26 @@ class EmlImportService {
 
         if (!contact && (hasEmail || hasName)) {
             contact = new Contact()
-            contact.firstName = emlElement.individualName.givenName
-            contact.lastName = emlElement.individualName.surName
-            // some email has leading/trailing spaces causing the email constrain regexp to fail, lets trim
-            contact.email = emlElement.electronicMailAddress.text().trim()
-            contact.setUserLastModified(collectoryAuthService.username())
-            Contact.withTransaction {
-                if (contact.validate()) {
-                    contact.save(flush: true, failOnError: true)
-                    return contact
-                } else {
-                    contact.errors.each {
-                        log.error("Problem creating contact: " + it)
-                    }
-                    return null
+        }
+
+        // Update the contact details
+        contact.firstName = emlElement.individualName.givenName
+        contact.lastName = emlElement.individualName.surName
+        // some email has leading/trailing spaces causing the email constrain regexp to fail, lets trim
+        contact.email = emlElement.electronicMailAddress.text().trim()
+        contact.setUserLastModified(collectoryAuthService.username())
+        Contact.withTransaction {
+            if (contact.validate()) {
+                contact.save(flush: true, failOnError: true)
+                return contact
+            } else {
+                contact.errors.each {
+                    log.error("Problem creating contact: " + it)
                 }
+                return null
             }
         }
+
         contact
     }
 }

--- a/grails-app/services/au/org/ala/collectory/IptService.groovy
+++ b/grails-app/services/au/org/ala/collectory/IptService.groovy
@@ -119,11 +119,14 @@ class IptService {
                                 }
                             }
 
-                            def emails = old.getContacts().collect { it.contact.email }
-
                             //sync contacts
                             update.contacts.each { contact ->
-                                if (!emails.contains(contact.email)) {
+                                def existingContact = old.getContacts().find {
+                                    (it.contact.email && !it.contact.email.isEmpty() && it.contact.email == contact.email) ||
+                                            (it.contact.firstName == contact.firstName && it.contact.lastName == contact.lastName)
+                                }
+                                if (!existingContact) {
+                                    // Add new contact
                                     old.addToContacts(contact, null, false, true, collectoryAuthService.username())
                                 }
                             }

--- a/grails-app/services/au/org/ala/collectory/IptService.groovy
+++ b/grails-app/services/au/org/ala/collectory/IptService.groovy
@@ -127,7 +127,8 @@ class IptService {
                                 }
                                 if (!existingContact) {
                                     // Add new contact
-                                    old.addToContacts(contact, null, false, true, collectoryAuthService.username())
+                                    boolean isPrimaryContact = update.primaryContacts.contains(contact)
+                                    old.addToContacts(contact, null, false, isPrimaryContact, collectoryAuthService.username())
                                 }
                             }
                         }
@@ -145,7 +146,8 @@ class IptService {
                         DataResource.withTransaction {
                             update.resource.save(flush: true, failOnError: true)
                             update.contacts.each { contact ->
-                                update.resource.addToContacts(contact, null, false, true, collectoryAuthService.username())
+                                boolean isPrimaryContact = update.primaryContacts.contains(contact)
+                                update.resource.addToContacts(contact, null, false, isPrimaryContact, collectoryAuthService.username())
                             }
                         }
                         activityLogService.log username, admin, Action.CREATE, "Created new IPT data resource for provider " + provider.uid  + " with uid " + update.resource.uid + " for dataset " + update.resource.websiteUrl
@@ -206,11 +208,14 @@ class IptService {
         resource.isShareableWithGBIF = isShareableWithGBIF
 
         def contacts = []
+        def primaryContacts = []
         if (eml != null && eml != "") {
-            contacts = retrieveEml(resource, eml)
+            def result = retrieveEml(resource, eml)
+            contacts = result.contacts
+            primaryContacts = result.primaryContacts
         }
 
-        [resource: resource, contacts: contacts]
+        [resource: resource, contacts: contacts, primaryContacts: primaryContacts]
     }
 
     /**


### PR DESCRIPTION
This PR fix #116. Basically:

- Takes into account other contact fields
- Update also contacts without email
- Prevent to incorrect associate drs to the first contact without email as `Contact.findByEmail(empty)` was picked in this case.
- Do not fail if an email has a trailing or leading space.