### PR TITLE
Fix places where Events data resources should be treated as having records

### DIFF
--- a/grails-app/assets/javascripts/datasets.js
+++ b/grails-app/assets/javascripts/datasets.js
@@ -148,14 +148,14 @@ function appendResource(value) {
     $rowB.append('<span><strong class="resultsLabelFirst">'+ jQuery.i18n.prop('datasets.js.appendresource06') +': </strong>' + jQuery.i18n.prop('dataset.result.'+ value.resourceType) + '</span>');  // resource type
     $rowB.append('<span><strong class="resultsLabel">'+ jQuery.i18n.prop('datasets.js.appendresource07') +': </strong>' + (value.licenseType == null ? '' : value.licenseType) + '</span>'); // license type
 
-    if (COLLECTORY_CONF.showExtraInfoInDataSetsView && value.resourceType == 'records') {
+    if (COLLECTORY_CONF.showExtraInfoInDataSetsView && (value.resourceType == 'records' || value.resourceType == 'events')) {
         $rowB.append('<span><strong class="lastUpdatedDrView">'+ jQuery.i18n.prop('datasets.js.lastUpdated') +': </strong>' + formatLastUpdated() + '</span>'); // last updated
         var numRecords = drCount(value.uid);
         if (numRecords >= 0) {
             $rowB.append('<span><strong class="drNumRecordsDrView">' + jQuery.i18n.prop('datasets.js.numRecords') + ': </strong><a title="' + jQuery.i18n.prop('datasets.js.appendresource03') + '" href="' + biocacheUrl + '/occurrences/search?q=data_resource_uid:' + value.uid + '">' + numRecords + '</a></span>'); // recors link with numbers
         }
     }
-    if (!COLLECTORY_CONF.showExtraInfoInDataSetsView && value.resourceType == 'records') {
+    if (!COLLECTORY_CONF.showExtraInfoInDataSetsView && (value.resourceType == 'records' || value.resourceType == 'events')) {
         $rowB.append('<span class="viewRecords"><a title="' + jQuery.i18n.prop('datasets.js.appendresource03') + '" href="' + biocacheUrl + '/occurrences/search?q=data_resource_uid:' + value.uid + '">'+ jQuery.i18n.prop('datasets.js.appendresource10') +'</a></span>'); // records link
 
     }

--- a/grails-app/views/dataResource/contribution.gsp
+++ b/grails-app/views/dataResource/contribution.gsp
@@ -92,7 +92,7 @@
                 <cl:connectionParameters bean="command" connectionParameters="${command.connectionParameters}"/>
             </div>
 
-            <g:if test="${command.resourceType == 'records'}">
+            <g:if test="${command.resourceType == 'records'} || ${command.resourceType == 'events'}">
                 <!-- darwin core defaults -->
                 <div><h3><g:message code="dataresource.contribution.table0201" /></h3></div>
                 <div><g:message code="dataresource.contribution.table0301" />.</div>

--- a/grails-app/views/dataResource/show.gsp
+++ b/grails-app/views/dataResource/show.gsp
@@ -254,7 +254,7 @@
 
                 <cl:showConnectionParameters connectionParameters="${instance.connectionParameters}"/></p>
 
-                <g:if test="${instance.resourceType == 'records'}">
+                <g:if test="${instance.resourceType == 'records'} || ${instance.resourceType == 'events'}">
                     <!-- darwin core defaults -->
                     <g:set var="dwc" value="${instance.defaultDarwinCoreValues ? JSON.parse(instance.defaultDarwinCoreValues) : [:]}"/>
                     <h3>Default values for DwC fields</h3>
@@ -324,7 +324,7 @@
               <g:render template="/shared/location" model="[instance: instance]"/>
 
               <!-- Record consumers -->
-              <g:if test="${instance.resourceType == 'records'}">
+              <g:if test="${instance.resourceType == 'records'} || ${instance.resourceType == 'events'}">
                   <g:render template="/shared/consumers" model="[instance: instance]"/>
               </g:if>
 

--- a/grails-app/views/public/showDataResource.gsp
+++ b/grails-app/views/public/showDataResource.gsp
@@ -376,7 +376,7 @@
                 if (loadLoggerStats){
                     if (${instance.resourceType == 'website'}) {
                       loadDownloadStats("${grailsApplication.config.loggerURL}", "${instance.uid}","${instance.name}", "2000");
-                  } else if (${instance.resourceType == 'records'}) {
+                  } else if (${instance.resourceType == 'records'} || ${instance.resourceType == 'events'}) {
                       loadDownloadStats("${grailsApplication.config.loggerURL}", "${instance.uid}","${instance.name}", "1002");
                   }
                 }


### PR DESCRIPTION
This PR relates to https://github.com/AtlasOfLivingAustralia/collectory/issues/235.

It fixes a few other places where Events typed data resources should be treated as having records.

- *Usage stats* tab on public data resource page
- Listing on /datasets page
- Data resource page in admin interface 