### PR TITLE
Fix broken reset button on datasets listing page

### DIFF
--- a/grails-app/assets/javascripts/datasets.js
+++ b/grails-app/assets/javascripts/datasets.js
@@ -763,8 +763,9 @@ function reset() {
     offset = 0;
     $('select#per-page').val(20);
     $('select#sort').val('name');
-    $('select#dir').val('asc');
+    $('select#dir').val('ascending');
     $.bbq.removeState();
+    resources.sort(comparator);
     updateTotal();
     calculateFacets();
     showFilters();

--- a/grails-app/views/public/dataSets.gsp
+++ b/grails-app/views/public/dataSets.gsp
@@ -72,7 +72,7 @@
                             </div><!-- /input-group -->
 
                             <div class="pull-right">
-                                <button href="javascript:reset()" title="${message(code:"datasets.remove.all.filters")}" class=" form-control btn btn-default">
+                                <button href="#" id="resetLink" title="${message(code:"datasets.remove.all.filters")}" class=" form-control btn btn-default">
                                     <g:message code="public.datasets.drsearch.resetlist" />
                                 </button>
                                 <button href="#" id="downloadLink" class="btn btn-default"
@@ -122,6 +122,7 @@
           $('select#per-page').change(onPageSizeChange);
           $('select#sort').change(onSortChange);
           $('select#dir').change(onDirChange);
+          $('#resetLink').click(reset);
       });
   </asset:script>
   </body>


### PR DESCRIPTION
Fixes wiring of **Reset list** button on datasets listing page (/datasets) and also some minor bugs in the `reset()` function.

Has been implemented here: https://collections.biodiversitydata.se/datasets