### PR TITLE
Remove misleading tooltip on datasets listing page

### DIFF
--- a/grails-app/assets/javascripts/datasets.js
+++ b/grails-app/assets/javascripts/datasets.js
@@ -140,7 +140,7 @@ function appendResource(value) {
     }
 
     // row A
-    $rowA.append('<img title="'+ jQuery.i18n.prop('datasets.js.appendresource01') + '" src="' + baseUrl + '/static/images/skin/ExpandArrow.png"/>');  // twisty
+    $rowA.append('<img src="' + baseUrl + '/static/images/skin/ExpandArrow.png"/>');  // twisty
     $rowA.append('<span class="result-name"><a title="' + jQuery.i18n.prop('datasets.js.appendresource02') + '" href="' + baseUrl + '/public/showDataResource/' + value.uid + '">' + value.name + '</a></span>'); // name
     // $rowA.find('img').tooltip($.extend({},tooltipOptions,{position:{my: 'center bottom', at: 'center top-10'}}));
 

--- a/grails-app/assets/stylesheets/main.css
+++ b/grails-app/assets/stylesheets/main.css
@@ -23,10 +23,6 @@
     padding-top:8px;
 }
 
-.rowA img {
-    cursor: pointer;
-}
-
 .rowA, .rowB {
     padding-bottom: 0 !important;
 }


### PR DESCRIPTION
On the datasets listing page (/datasets) there is a small arrow icon in front of each item in the list. The arrow appears clickable and shows the tooltip "Click to show more information". Nothing happens when you click it.

The code that's supposed to show more information is out commented and seems unfinished. This PR "fixes" this by removing the misleading tooltip and the clickable appearance of the icon.