### PR TITLE
Hide progress bar on collection page if no estimated specimens count

### DIFF
--- a/grails-app/views/public/_progress.gsp
+++ b/grails-app/views/public/_progress.gsp
@@ -33,8 +33,8 @@ function setPercentAgeNumbers(totalBiocacheRecords, totalRecords) {
         }
         setProgress(percent);
     } else {
-        // to update the speedo caption
-        setProgress(0);
+        // the progress bar doesn't make sense if there is no estimated speciemens count
+        $('#progress').hide();
     }
 }
 


### PR DESCRIPTION
On the Records tab of the collection page there is a progress bar showing how many of the total/estimated number of specimens in the collection are available in the LA portal. However, if the total number of specimens is not available it defaults to displaying the message "No records are available for viewing..." which is often wrong and produces a very confusing page where the left part says there are a lot of records available and the right part says no records:

![Screenshot-2](https://github.com/user-attachments/assets/c49dd641-1400-4200-978e-a5f4d4330b86)

This PR fixes this by simply hiding the progress bar if the total/estimated number of specimens is not available since the progress bar makes no sense at all in that case.