### PR TITLE
Correct coordinate parsing logic for lat & long for several locales

### DIFF
--- a/grails-app/controllers/au/org/ala/collectory/ProviderGroupController.groovy
+++ b/grails-app/controllers/au/org/ala/collectory/ProviderGroupController.groovy
@@ -4,7 +4,6 @@ import au.org.ala.PermissionRequired
 import au.org.ala.collectory.resources.PP
 import grails.converters.JSON
 import org.springframework.dao.DataIntegrityViolationException
-import org.springframework.web.context.request.RequestContextHolder
 import org.springframework.web.multipart.MultipartFile
 import java.text.NumberFormat
 import java.text.ParseException
@@ -306,19 +305,9 @@ abstract class ProviderGroupController {
         if (pg) {
             if (checkLocking(pg,'/shared/location')) { return }
 
-            Locale userLocale = (RequestContextHolder.currentRequestAttributes() as ServletRequestAttributes).request.locale
-            NumberFormat numberFormat = NumberFormat.getNumberInstance(userLocale)
-
-            double latitude
-            double longitude
-
-            try {
-                latitude = params.latitude ? numberFormat.parse(params.latitude).doubleValue() : -1
-                longitude = params.longitude ? numberFormat.parse(params.longitude).doubleValue() : -1
-            } catch (ParseException e) {
-                latitude = -1
-                longitude = -1
-            }
+            // special handling for lat & long
+            def latitude = parseCoordinate(params.latitude)
+            def longitude = parseCoordinate(params.longitude)
 
             // special handling for embedded address - need to create address obj if none exists and we have data
             if (!pg.address && [params.address?.street, params.address?.postBox, params.address?.city,
@@ -327,7 +316,7 @@ abstract class ProviderGroupController {
             }
 
             pg.properties = params
-            pg.latitude  = latitude
+            pg.latitude = latitude
             pg.longitude = longitude
             pg.userLastModified = collectoryAuthService?.username()
 
@@ -938,4 +927,14 @@ abstract class ProviderGroupController {
         }
         return false
     }
+
+    private Double parseCoordinate(Object value) {
+        if (value == null || value.toString().trim().isEmpty()) return -1
+        try {
+            return Double.parseDouble(value.toString().replace(",", "."))
+        } catch (NumberFormatException e) {
+            return -1
+        }
+    }
 }
+


### PR DESCRIPTION

Although #189 addressed the #188 issue of editing latitude and longitude fields in collections, some users are still experiencing an exception when modifying these fields:
```
[2024-11-11 09:32:49] [info] Caused by: com.mysql.cj.jdbc.exceptions.MysqlDataTruncation: Data truncation: Out of range value for column 'latitude' at row 1
```
This PR proposes a different approach to fully resolve this issue by ensuring latitude and longitude values are consistently converted to valid double formats, independent of user locale. This aims to prevent data truncation errors by enforcing a standard format across all inputs.