### PR TITLE
Restore subcollections resize fixed in collectory-plugin

### DIFF
--- a/grails-app/domain/au/org/ala/collectory/Collection.groovy
+++ b/grails-app/domain/au/org/ala/collectory/Collection.groovy
@@ -163,7 +163,7 @@ class Collection implements ProviderGroup, Serializable {
                 return ok
             })
         scientificNames(nullable:true, maxSize:2048)
-        subCollections(nullable:true, maxSize:8192)
+        subCollections(nullable:true, maxSize:20480)
         providerMap(nullable:true)
         institution(nullable:true)
     }

--- a/grails-app/domain/au/org/ala/collectory/Collection.groovy
+++ b/grails-app/domain/au/org/ala/collectory/Collection.groovy
@@ -163,7 +163,7 @@ class Collection implements ProviderGroup, Serializable {
                 return ok
             })
         scientificNames(nullable:true, maxSize:2048)
-        subCollections(nullable:true, maxSize:4096)
+        subCollections(nullable:true, maxSize:8192)
         providerMap(nullable:true)
         institution(nullable:true)
     }

--- a/grails-app/migrations/changelog.xml
+++ b/grails-app/migrations/changelog.xml
@@ -460,4 +460,8 @@ liquibase.command.referencePassword: XXXXX
         </addColumn>
     </changeSet>
 
+    <changeSet author="vjrj" id="20241122-01">
+        <modifyDataType tableName="collection" columnName="sub_collections" newDataType="TEXT"/>
+    </changeSet>
+    
 </databaseChangeLog>


### PR DESCRIPTION
This restore AtlasOfLivingAustralia/collectory-plugin#182 that fixed AtlasOfLivingAustralia/collectory-plugin#181. 

I added the field migration to `liquibase` as this part was done automatically in `collectory-plugin` and now via `liquibase`.