### PR TITLE
Fix for 266

### DIFF
--- a/grails-app/assets/javascripts/map.js
+++ b/grails-app/assets/javascripts/map.js
@@ -145,11 +145,6 @@ function setLabels(data){
 
     // update display of number of features
     var selectedFilters = getSelectedFiltersAsString();
-    var selectedFrom = jQuery.i18n.prop('map.js.collectionstotal');
-    if (selectedFilters != 'all') {
-        selectedFrom = jQuery.i18n.prop(selectedFilters)+ " " + jQuery.i18n.prop('collections');
-    }
-    var innerFeatures = "";
 
     collectionsCount = 0;
 
@@ -159,12 +154,18 @@ function setLabels(data){
         }
     });
 
+    var selectedFrom = jQuery.i18n.prop('map.js.collectionstotalarg', collectionsCount);
+    if (selectedFilters != 'all') {
+        selectedFrom = jQuery.i18n.prop("map.js.totalcollectionsfiltered", collectionsCount, jQuery.i18n.prop(selectedFilters))
+    }
+    var innerFeatures = "";
+
     switch (collectionsCount) {
         //case 0: innerFeatures = "No collections are selected."; break;
         //case 1: innerFeatures = "One collection is selected."; break;
         case 0: innerFeatures = jQuery.i18n.prop('map.js.nocollectionsareselected'); break;
         case 1: innerFeatures = jQuery.i18n.prop('map.js.onecollectionisselected'); break;
-        default: innerFeatures = collectionsCount + " " + selectedFrom + "."; break;
+        default: innerFeatures = selectedFrom; break;
     }
     $('span#numFeatures').html(innerFeatures);
 

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -1878,10 +1878,12 @@ dataAccess.alert.annotations.alt=Alert me about annotations
 
 # Javascript i18n
 map.js.collectionstotal=collections in total
+map.js.collectionstotalarg={0} collections in total.
 map.js.collectioncannotbemapped=collection cannot be mapped.
 map.js.collectionscannotbemapped=collections cannot be mapped.
 map.js.nocollectionsareselected=No collections are selected.
 map.js.onecollectionisselected=One collection is selected.
+map.js.totalcollectionsfiltered={0} {1} collections.
 map.js.collectionislisted=collection is listed
 map.js.collectionsarelistedalphabetically=collections are listed alphabetically
 map.js.nocollectionsarecurrentlyvisible=No collections are currently visible on the map.


### PR DESCRIPTION
This pull request refactors the `setLabels` function in `map.js` to improve internationalization (i18n) support and updates the corresponding i18n strings in `messages.properties`. 

With this PR, the totals are correct in English:

![image](https://github.com/user-attachments/assets/cbeb064d-b2c7-4c83-9155-01213cadc23a)
![image](https://github.com/user-attachments/assets/38720a19-ee57-41b9-8fcd-7e504910d67d)

but also in Spanish (with a sentence with different order):

![image](https://github.com/user-attachments/assets/06656ffb-6c70-43f0-a7b0-ec28b3804e49)

without this PR (wrong sentence):

![image](https://github.com/user-attachments/assets/d0a2750e-fbc9-4491-80fe-1639f1f593d9)


The older messages without arguments are preserved to maintain compatibility with older versions of `collectory`.

This is a fix for #266.