### PR TITLE
Fix for 264

### DIFF
--- a/grails-app/assets/javascripts/datasets.js
+++ b/grails-app/assets/javascripts/datasets.js
@@ -308,7 +308,8 @@ function filterBy(filter, uidList) {
             }
         }
         // filter by equality
-        else if (resource[filter.name] == filter.value || (filter.value == 'noValue' && resource[filter.name] == null)) {
+        else if (resource[filter.name] == filter.value ||
+            (filter.value == 'noValue' && (resource[filter.name] == null || resource[filter.name] === ''))) {
             newResourcesList.push(resource);
         }
     });


### PR DESCRIPTION
Fix for #264.

This pull request includes a small change that refines the filtering logic to account for empty string values in addition to `null` when the filter value is `'noValue'`.

![image](https://github.com/user-attachments/assets/ea4db652-f1e6-4ed2-9c7e-976e111c2f8a)

That fix the return of datasets when license type is empty aka "No information" : 

![image](https://github.com/user-attachments/assets/b4daccd1-2973-44b8-8cfc-b3068b011cac)

Before:

![image](https://github.com/user-attachments/assets/310f6109-9648-45bc-b2c5-2fbe3fece696)

but selecting the "No information":

Returns empty result:

![image](https://github.com/user-attachments/assets/494009b4-e8a3-4f43-a31f-23f16514373e)

