### PR TITLE
Add conditional rendering for species list & website section

### DIFF
--- a/grails-app/views/public/_showDataResourceWebsite.gsp
+++ b/grails-app/views/public/_showDataResourceWebsite.gsp
@@ -1,0 +1,33 @@
+<g:if test="${instance.resourceType == 'species-list'}">
+    <section class="public-metadata">
+        <g:if test="${showHeaders}">
+            <h4><g:message code="public.sdr.content.label12" /></h4>
+        </g:if>
+        <div class="webSite">
+            <a class='external_icon' target="_blank"
+               href="${grailsApplication.config.speciesListToolUrl}${instance.uid}"><g:message code="public.sdr.content.link03" /></a>
+        </div>
+    </section>
+</g:if>
+<g:elseif test="${instance.resourceType == 'publications'}">
+    <section class="public-metadata">
+        <g:if test="${showHeaders}">
+            <h4><g:message code="public.website" /></h4>
+        </g:if>
+        <div class="webSite">
+            <a class='external_icon' target="_blank"
+               href="${instance.websiteUrl}"><g:message code="public.sdr.content.link05" /></a>
+        </div>
+    </section>
+</g:elseif>
+<g:elseif test="${instance.websiteUrl}">
+    <section class="public-metadata">
+        <g:if test="${showHeaders}">
+            <h4><g:message code="public.website" /></h4>
+        </g:if>
+        <div class="webSite">
+            <a class='external_icon' target="_blank"
+               href="${instance.websiteUrl}"><g:message code="public.sdr.content.link04" /></a>
+        </div>
+    </section>
+</g:elseif>

--- a/grails-app/views/public/showDataResource.gsp
+++ b/grails-app/views/public/showDataResource.gsp
@@ -1,5 +1,6 @@
 <%@ page import="au.org.ala.collectory.CollectoryTagLib; java.text.DecimalFormat; java.text.SimpleDateFormat" %>
 <g:set var="orgNameLong" value="${grailsApplication.config.skin.orgNameLong}"/>
+<g:set var="showBelowH3" value="${grailsApplication.config.showDataResourceWebsiteBelowH3.toBoolean()?: false}" />
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
@@ -229,6 +230,10 @@
                 </section>
             </g:if>
 
+            <g:if test="${showBelowH3}">
+                <g:render template="showDataResourceWebsite" model="[instance: instance, showHeaders: false]" />
+            </g:if>
+
             <g:if test="${instance.gbifDoi}">
                 <section class="public-metadata">
                     <h4><g:message code="public.citations" default="Citations" /></h4>
@@ -301,34 +306,10 @@
             </g:else>
             <g:render template="contacts" bean="${contacts}"/>
 
-           <!-- web site -->
-            <g:if test="${instance.resourceType == 'species-list'}">
-                <section class="'public-metadata">
-                    <h4><g:message code="public.sdr.content.label12" /></h4>
-                    <div class="webSite">
-                        <a class='external_icon' target="_blank"
-                           href="${grailsApplication.config.speciesListToolUrl}${instance.uid}"><g:message code="public.sdr.content.link03" /></a>
-                    </div>
-                </section>
+            <!-- web site -->
+            <g:if test="${!showBelowH3}">
+                <g:render template="showDataResourceWebsite" model="[instance: instance, showHeaders: true]" />
             </g:if>
-            <g:elseif test="${instance.resourceType == 'publications'}">
-                <section class="public-metadata">
-                    <h4><g:message code="public.website" /></h4>
-                    <div class="webSite">
-                        <a class='external_icon' target="_blank"
-                           href="${instance.websiteUrl}"><g:message code="public.sdr.content.link05" /></a>
-                    </div>
-                </section>
-            </g:elseif>
-            <g:elseif test="${instance.websiteUrl}">
-                <section class="public-metadata">
-                    <h4><g:message code="public.website" /></h4>
-                    <div class="webSite">
-                        <a class='external_icon' target="_blank"
-                           href="${instance.websiteUrl}"><g:message code="public.sdr.content.link04" /></a>
-                    </div>
-                </section>
-            </g:elseif>
 
             <!-- network membership -->
             <g:if test="${instance.networkMembership}">


### PR DESCRIPTION
This pull request refactors how website links are displayed for data resources by introducing a reusable template and adds configurability for where these links appear on the page:

- Moved the logic for displaying website links (based on `resourceType` and `websiteUrl`) into a new reusable template, `_showDataResourceWebsite.gsp`, to reduce duplication and improve maintainability.
* Added a new configuration property, `showDataResourceWebsiteBelowH3`, to control whether website links should appear below the `<h3>` header or in their original location (disabled by default, so this should not affect current display of datasets).
- Updated `showDataResource.gsp` to use the new configuration property and the reusable template for rendering website links, ensuring consistent behavior and layout based on the configuration. 

Before:

![image](https://github.com/user-attachments/assets/49ed280f-41fe-4f4f-a638-37a3f016b5ee)

![image](https://github.com/user-attachments/assets/dddf173d-e090-46fb-8107-0c2210635f9a)

After this PR with `showDataResourceWebsiteBelowH3=true`:

![image](https://github.com/user-attachments/assets/1a19d465-46de-4d59-91a5-d7f1d1c565ee)


![image](https://github.com/user-attachments/assets/c82e7e81-8665-4d69-88ff-a5da09987c58)


Fix for #274.