### PR TITLE
Update GbifService.groovy to fix "Upload GBIF file"

### DIFF
--- a/grails-app/services/au/org/ala/collectory/GbifService.groovy
+++ b/grails-app/services/au/org/ala/collectory/GbifService.groovy
@@ -199,7 +199,7 @@ class GbifService {
                 map.get("citation", xml.additionalMetadata.metadata.gbif.citation.toString())
                 map.get("rights", xml.additionalMetadata.metadata.gbif.rights.toString())
 
-                log.debug(map)
+                log.debug(map.toString())
 
             } else if (file.getName() == OCCURRENCE_FILE){
                 //save the record to the "directoryForArchive"


### PR DESCRIPTION
Fixes #293 

Fix to upload a GBIF file from the website UI failing with:

```
[2025-11-14 16:58:59] [info] 2025-11-14 16:58:59.585 ERROR --- [0.1-8080-exec-9] a.o.a.c.ProviderGroupController         : No signature of method: ch.qos.logback.classic.Logger.debug() is applicable for argument types: (LinkedHashMap) values: [[rights:Dataset: Global Roadkill Data...]]
[2025-11-14 16:58:59] [info] groovy.lang.MissingMethodException: No signature of method: ch.qos.logback.classic.Logger.debug() is applicable for argument types: (LinkedHashMap) values: [[rights:Dataset: Global Roadkill Data...]]
```