### PR TITLE
IptService update logic ensuring required fields are never set to null during updates

### DIFF
--- a/grails-app/services/au/org/ala/collectory/IptService.groovy
+++ b/grails-app/services/au/org/ala/collectory/IptService.groovy
@@ -76,10 +76,18 @@ class IptService {
      */
     @org.springframework.transaction.annotation.Transactional(propagation = org.springframework.transaction.annotation.Propagation.REQUIRED)
     def scan(DataProvider provider, boolean create, boolean check, String keyName, String username, boolean admin, boolean shareWithGbif) {
+        long startTime = System.currentTimeMillis()
+        log.info("Starting scan for provider ${provider.uid}")
         activityLogService.log username, admin, provider.uid, Action.SCAN
         def updates = this.rss(provider, keyName, shareWithGbif)
 
-        return merge(provider, updates, create, check, username, admin)
+        def result = merge(provider, updates, create, check, username, admin)
+
+        long endTime = System.currentTimeMillis()
+        long durationMinutes = (endTime - startTime) / 60000
+        log.info("Scan for provider ${provider.uid} completed in ${durationMinutes} minutes")
+
+        return result
     }
 
     /**
@@ -126,11 +134,15 @@ class IptService {
         def fieldsToUpdate = allFields() // Retrieves all fields that can be updated
         log.info("Fields to update: ${fieldsToUpdate}")
 
+        // Define required fields that should never be set to null (fields with nullable:false in constraints)
+        def requiredFields = ['uid', 'name', 'status', 'resourceType', 'gbifDataset', 'isShareableWithGBIF', 'makeContactPublic']
+
         fieldsToUpdate.each { fieldName ->
             if (update.containsKey(fieldName)) {
                 def newValue = update[fieldName]
                 existingResource.setProperty(fieldName, newValue) // Update the field with the new value (even if it's null)
-            } else {
+            } else if (!requiredFields.contains(fieldName)) {
+                // Only clear non-required fields
                 existingResource.setProperty(fieldName, null) // Clear the field if it doesn't exist in the update
             }
         }

--- a/src/test/groovy/au/org/ala/collectory/IptServiceSpec.groovy
+++ b/src/test/groovy/au/org/ala/collectory/IptServiceSpec.groovy
@@ -25,6 +25,7 @@ class IptServiceSpec extends Specification implements ServiceUnitTest<IptService
                     "guid"                 : { eml -> eml.@packageId.toString() },
                     "name"                 : { eml -> eml.dataset.title.toString() },
                     "pubDescription"       : { eml -> "Sample description" },
+                    "websiteUrl"           : { eml -> "http://example.org" },
                     "methodStepDescription": { eml -> "Sample method step description" }
             ].keySet()
         }
@@ -697,6 +698,98 @@ class IptServiceSpec extends Specification implements ServiceUnitTest<IptService
         Contact.count() == 1
         ContactFor.countByEntityUid(resource.uid) == 1
         Contact.findByEmail("john@example.com").organizationName == null
+    }
+
+    void "test updateFields does not set required fields to null"() {
+        given: "A resource with required fields and an update without some fields"
+        def resource = new DataResource(
+                uid: "dr1",
+                name: "Original Name",
+                guid: "original-guid",
+                websiteUrl: "http://example.org/resource",
+                pubDescription: "Original Description",
+                userLastModified: "originalUser"
+        ).save(flush: true, failOnError: true)
+
+        def update = [
+                guid: "original-guid",
+                pubDescription: "New Description",
+                websiteUrl: "http://example.org/updated"
+        ]
+
+        when: "updateFields is called with some fields missing from the mock allFields()"
+        service.updateFields(resource, update, "testUser")
+
+        then: "Required field 'name' is NOT cleared even if missing from allFields"
+        resource.name == "Original Name"
+
+        and: "Optional fields are updated correctly"
+        resource.pubDescription == "New Description"
+        resource.websiteUrl == "http://example.org/updated"
+    }
+
+    void "test updateFields clears optional fields not in update"() {
+        given: "A resource with optional fields set"
+        def resource = new DataResource(
+                uid: "dr1",
+                name: "Test Resource",
+                guid: "test-guid",
+                websiteUrl: "http://example.org/resource",
+                pubDescription: "Description to remove",
+                methodStepDescription: "Method to remove",
+                userLastModified: "originalUser"
+        ).save(flush: true, failOnError: true)
+
+        def update = [
+                name: "Updated Name",
+                guid: "test-guid",
+                websiteUrl: "http://example.org/resource"
+                // pubDescription and methodStepDescription NOT in update
+        ]
+
+        when: "updateFields is called"
+        service.updateFields(resource, update, "testUser")
+
+        then: "Required field 'name' is preserved"
+        resource.name == "Updated Name"
+
+        and: "Optional fields are cleared"
+        resource.pubDescription == null
+        resource.methodStepDescription == null
+    }
+
+    void "test updateFields preserves required fields when null values come from update"() {
+        given: "A resource with all fields set"
+        def resource = new DataResource(
+                uid: "dr1",
+                name: "Resource Name",
+                guid: "resource-guid",
+                websiteUrl: "http://example.org/resource",
+                pubDescription: "Description",
+                methodStepDescription: "Method",
+                userLastModified: "originalUser"
+        ).save(flush: true, failOnError: true)
+
+        def update = [
+                name: "Resource Name",
+                guid: "resource-guid",
+                websiteUrl: "http://example.org/resource",
+                pubDescription: null, // Explicitly null to clear
+                methodStepDescription: null // Explicitly null to clear
+        ]
+
+        when: "updateFields is called with explicit nulls"
+        service.updateFields(resource, update, "testUser")
+
+        then: "Required field 'name' is preserved even with other nulls"
+        resource.name == "Resource Name"
+
+        and: "Optional fields are cleared"
+        resource.pubDescription == null
+        resource.methodStepDescription == null
+
+        and: "No validation errors occur"
+        !resource.hasErrors()
     }
 
     void "test syncContacts updates contact when name is updated"() {


### PR DESCRIPTION
This pull request improves the robustness and reliability of the `IptService` update logic by ensuring required fields are never set to null during updates, and adds comprehensive tests to cover these scenarios. It also introduces logging to track scan durations for better observability.

This fix #295.