### PR TITLE
Fix IPT scan: EML metadata fields not updating and name set to null

### DIFF
--- a/grails-app/services/au/org/ala/collectory/EmlImportService.groovy
+++ b/grails-app/services/au/org/ala/collectory/EmlImportService.groovy
@@ -29,17 +29,17 @@ class EmlImportService {
         pubDescription: { eml ->
             def paras = this.collectParas(eml.dataset.abstract?.para)
             // Fallback: if no <para> children, use the <abstract> text directly.
-            (paras != null && !paras.isEmpty()) ? paras : eml.dataset.abstract?.text()?.trim() ?: null
+            (paras != null && !paras.isEmpty()) ? paras : (eml.dataset.abstract?.text()?.trim() ?: "")
         },
         name: { eml -> eml.dataset.title.toString() },
-        email: { eml ->  eml.dataset.contact.size() > 0 ? eml.dataset.contact[0]?.electronicMailAddress?.text(): null },
-        rights: { eml ->  this.collectParas(eml.dataset.intellectualRights?.para) },
+        email: { eml ->  eml.dataset.contact.size() > 0 ? (eml.dataset.contact[0]?.electronicMailAddress?.text() ?: "") : "" },
+        rights: { eml ->  this.collectParas(eml.dataset.intellectualRights?.para) ?: "" },
         citation: { eml ->
             def node = eml.additionalMetadata?.metadata?.gbif?.citation
-            node?.size() > 0 ? node.text() : null },
+            node?.size() > 0 ? node.text() : "" },
         state: { eml ->
 
-            def state = null
+            def state = ""
 
             def administrativeAreas = eml.dataset.contact.size() > 0 ? eml.dataset.contact[0]?.address?.administrativeArea: null
             if (administrativeAreas){
@@ -51,48 +51,48 @@ class EmlImportService {
                     stateText = administrativeAreas.text()
                 }
                 if (stateText) {
-                    state = this.dataLoaderService.massageState(stateText)
+                    state = this.dataLoaderService.massageState(stateText) ?: ""
                 }
             }
             state
         },
-        phone: { eml ->  eml.dataset.contact.size() > 0 ? eml.dataset.contact[0]?.phone?.text(): null },
+        phone: { eml ->  eml.dataset.contact.size() > 0 ? (eml.dataset.contact[0]?.phone?.text() ?: "") : "" },
 
         //geographic coverage
         geographicDescription: { eml ->
             def node = eml.dataset.coverage?.geographicCoverage?.geographicDescription
-            node?.size() > 0 ? node.text() : null },
+            node?.size() > 0 ? node.text() : "" },
         northBoundingCoordinate: { eml ->
             def node = eml.dataset.coverage?.geographicCoverage?.boundingCoordinates?.northBoundingCoordinate
-            node?.size() > 0 ? node.text() : null },
+            node?.size() > 0 ? node.text() : "" },
         southBoundingCoordinate: { eml ->
             def node = eml.dataset.coverage?.geographicCoverage?.boundingCoordinates?.southBoundingCoordinate
-            node?.size() > 0 ? node.text() : null },
+            node?.size() > 0 ? node.text() : "" },
         eastBoundingCoordinate : { eml ->
             def node = eml.dataset.coverage?.geographicCoverage?.boundingCoordinates?.eastBoundingCoordinate
-            node?.size() > 0 ? node.text() : null },
+            node?.size() > 0 ? node.text() : "" },
         westBoundingCoordinate: { eml ->
             def node = eml.dataset.coverage?.geographicCoverage?.boundingCoordinates?.westBoundingCoordinate
-            node?.size() > 0 ? node.text() : null },
+            node?.size() > 0 ? node.text() : "" },
 
         //temporal
         beginDate: { eml ->
             def node = eml.dataset.coverage?.temporalCoverage?.rangeOfDates?.beginDate?.calendarDate
-            node?.size() > 0 ? node.text() : null },
+            node?.size() > 0 ? node.text() : "" },
         endDate: { eml ->
             def node = eml.dataset.coverage?.temporalCoverage?.rangeOfDates?.endDate?.calendarDate
-            node?.size() > 0 ? node.text() : null },
+            node?.size() > 0 ? node.text() : "" },
 
         //additional fields
         purpose: { eml ->
             def node = eml.dataset.purpose?.para
-            node?.size() > 0 ? node.text() : null },
+            node?.size() > 0 ? node.text() : "" },
         methodStepDescription: { eml ->
             def node = eml.dataset.methods?.methodStep?.description?.para
-            node?.size() > 0 ? node.text() : null },
+            node?.size() > 0 ? node.text() : "" },
         qualityControlDescription: { eml ->
             def node = eml.dataset.methods?.qualityControl?.description?.para
-            node?.size() > 0 ? node.text() : null },
+            node?.size() > 0 ? node.text() : "" },
 
         gbifDoi: { eml ->
             def gbifDoi = null
@@ -171,11 +171,9 @@ class EmlImportService {
 
         emlFields.each { name, accessor ->
             def val = accessor(eml)
-            // Only skip null — accessors return null for absent nodes, "" for present-but-empty.
-            // "" is a legitimate value (explicit empty in EML) and should overwrite existing data.
-            if (val != null) {
-                dataResource.setProperty(name, val)
-            }
+            // EML is the source of truth: always apply the value, even if empty.
+            // Absent nodes return "" (not null), so existing data is cleared when the field is not in the EML.
+            dataResource.setProperty(name, val)
         }
 
         def addContact = { provider ->

--- a/grails-app/services/au/org/ala/collectory/EmlImportService.groovy
+++ b/grails-app/services/au/org/ala/collectory/EmlImportService.groovy
@@ -26,25 +26,32 @@ class EmlImportService {
     public emlFields = [
 
         guid:  { eml -> eml.@packageId.toString() },
-        pubDescription: { eml -> this.collectParas(eml.dataset.abstract?.para) },
+        pubDescription: { eml ->
+            def paras = this.collectParas(eml.dataset.abstract?.para)
+            // Fallback: if no <para> children, use the <abstract> text directly.
+            (paras != null && !paras.isEmpty()) ? paras : eml.dataset.abstract?.text()?.trim() ?: null
+        },
         name: { eml -> eml.dataset.title.toString() },
         email: { eml ->  eml.dataset.contact.size() > 0 ? eml.dataset.contact[0]?.electronicMailAddress?.text(): null },
         rights: { eml ->  this.collectParas(eml.dataset.intellectualRights?.para) },
-        citation: { eml ->  eml.additionalMetadata?.metadata?.gbif?.citation?.text() },
+        citation: { eml ->
+            def node = eml.additionalMetadata?.metadata?.gbif?.citation
+            node?.size() > 0 ? node.text() : null },
         state: { eml ->
 
-            def state = ""
+            def state = null
 
             def administrativeAreas = eml.dataset.contact.size() > 0 ? eml.dataset.contact[0]?.address?.administrativeArea: null
             if (administrativeAreas){
 
+                def stateText = ""
                 if (administrativeAreas.size() > 1){
-                    state = administrativeAreas.first().text()
+                    stateText = administrativeAreas.first().text()
                 } else {
-                    state = administrativeAreas.text()
+                    stateText = administrativeAreas.text()
                 }
-                if (state) {
-                    state = this.dataLoaderService.massageState(state)
+                if (stateText) {
+                    state = this.dataLoaderService.massageState(stateText)
                 }
             }
             state
@@ -52,20 +59,40 @@ class EmlImportService {
         phone: { eml ->  eml.dataset.contact.size() > 0 ? eml.dataset.contact[0]?.phone?.text(): null },
 
         //geographic coverage
-        geographicDescription: { eml -> eml.dataset.coverage?.geographicCoverage?.geographicDescription?:'' },
-        northBoundingCoordinate: { eml -> eml.dataset.coverage?.geographicCoverage?.boundingCoordinates?.northBoundingCoordinate?:''},
-        southBoundingCoordinate: { eml -> eml.dataset.coverage?.geographicCoverage?.boundingCoordinates?.southBoundingCoordinate?:''},
-        eastBoundingCoordinate : { eml -> eml.dataset.coverage?.geographicCoverage?.boundingCoordinates?.eastBoundingCoordinate?:''},
-        westBoundingCoordinate: { eml -> eml.dataset.coverage?.geographicCoverage?.boundingCoordinates?.westBoundingCoordinate?:''},
+        geographicDescription: { eml ->
+            def node = eml.dataset.coverage?.geographicCoverage?.geographicDescription
+            node?.size() > 0 ? node.text() : null },
+        northBoundingCoordinate: { eml ->
+            def node = eml.dataset.coverage?.geographicCoverage?.boundingCoordinates?.northBoundingCoordinate
+            node?.size() > 0 ? node.text() : null },
+        southBoundingCoordinate: { eml ->
+            def node = eml.dataset.coverage?.geographicCoverage?.boundingCoordinates?.southBoundingCoordinate
+            node?.size() > 0 ? node.text() : null },
+        eastBoundingCoordinate : { eml ->
+            def node = eml.dataset.coverage?.geographicCoverage?.boundingCoordinates?.eastBoundingCoordinate
+            node?.size() > 0 ? node.text() : null },
+        westBoundingCoordinate: { eml ->
+            def node = eml.dataset.coverage?.geographicCoverage?.boundingCoordinates?.westBoundingCoordinate
+            node?.size() > 0 ? node.text() : null },
 
         //temporal
-        beginDate: { eml -> eml.dataset.coverage?.temporalCoverage?.rangeOfDates?.beginDate?.calendarDate?:''},
-        endDate: { eml -> eml.dataset.coverage?.temporalCoverage?.rangeOfDates?.endDate?.calendarDate?:''},
+        beginDate: { eml ->
+            def node = eml.dataset.coverage?.temporalCoverage?.rangeOfDates?.beginDate?.calendarDate
+            node?.size() > 0 ? node.text() : null },
+        endDate: { eml ->
+            def node = eml.dataset.coverage?.temporalCoverage?.rangeOfDates?.endDate?.calendarDate
+            node?.size() > 0 ? node.text() : null },
 
         //additional fields
-        purpose: { eml -> eml.dataset.purpose?.para?:''},
-        methodStepDescription: { eml -> eml.dataset.methods?.methodStep?.description?.para?:''},
-        qualityControlDescription: { eml -> eml.dataset.methods?.qualityControl?.description?.para?:''},
+        purpose: { eml ->
+            def node = eml.dataset.purpose?.para
+            node?.size() > 0 ? node.text() : null },
+        methodStepDescription: { eml ->
+            def node = eml.dataset.methods?.methodStep?.description?.para
+            node?.size() > 0 ? node.text() : null },
+        qualityControlDescription: { eml ->
+            def node = eml.dataset.methods?.qualityControl?.description?.para
+            node?.size() > 0 ? node.text() : null },
 
         gbifDoi: { eml ->
             def gbifDoi = null
@@ -144,6 +171,8 @@ class EmlImportService {
 
         emlFields.each { name, accessor ->
             def val = accessor(eml)
+            // Only skip null — accessors return null for absent nodes, "" for present-but-empty.
+            // "" is a legitimate value (explicit empty in EML) and should overwrite existing data.
             if (val != null) {
                 dataResource.setProperty(name, val)
             }

--- a/grails-app/services/au/org/ala/collectory/EmlImportService.groovy
+++ b/grails-app/services/au/org/ala/collectory/EmlImportService.groovy
@@ -36,7 +36,7 @@ class EmlImportService {
         rights: { eml ->  this.collectParas(eml.dataset.intellectualRights?.para) ?: "" },
         citation: { eml ->
             def node = eml.additionalMetadata?.metadata?.gbif?.citation
-            node?.size() > 0 ? node.text() : "" },
+            node?.size() > 0 ? node.text().trim() : "" },
         state: { eml ->
 
             def state = ""
@@ -85,14 +85,11 @@ class EmlImportService {
 
         //additional fields
         purpose: { eml ->
-            def node = eml.dataset.purpose?.para
-            node?.size() > 0 ? node.text() : "" },
+            this.collectParas(eml.dataset.purpose?.para) ?: "" },
         methodStepDescription: { eml ->
-            def node = eml.dataset.methods?.methodStep?.description?.para
-            node?.size() > 0 ? node.text() : "" },
+            this.collectParas(eml.dataset.methods?.methodStep?.description?.para) ?: "" },
         qualityControlDescription: { eml ->
-            def node = eml.dataset.methods?.qualityControl?.description?.para
-            node?.size() > 0 ? node.text() : "" },
+            this.collectParas(eml.dataset.methods?.qualityControl?.description?.para) ?: "" },
 
         gbifDoi: { eml ->
             def gbifDoi = null

--- a/grails-app/services/au/org/ala/collectory/IptService.groovy
+++ b/grails-app/services/au/org/ala/collectory/IptService.groovy
@@ -103,14 +103,18 @@ class IptService {
             def existingResource = currentResources[update.resource.websiteUrl]
 
             if (existingResource) {
-                if (!check || existingResource.dataCurrency == null || update.resource.dataCurrency == null || update.resource.dataCurrency.after(existingResource.dataCurrency)) {
-                    DataResource.withTransaction {
-                        updateFields(existingResource, update, username)
-                        syncContacts(existingResource, update.contacts, update.primaryContacts, username, admin)
-                        activityLogService.log(username, admin, Action.EDIT_SAVE, "Updated IPT data resource ${existingResource.uid} from scan")
-                    }
+                // Always update EML metadata fields and contacts, regardless of dataCurrency.
+                // The dataCurrency check only determines whether this resource needs DwCA re-import
+                // (i.e. whether it appears in the returned list for the caller to act on).
+                DataResource.withTransaction {
+                    updateFields(existingResource, update.resource, username)
+                    syncContacts(existingResource, update.contacts, update.primaryContacts, username, admin)
+                    activityLogService.log(username, admin, Action.EDIT_SAVE, "Updated IPT data resource ${existingResource.uid} from scan")
                 }
-                mergedResources << existingResource
+                // Only include in the re-import list when data currency has increased (or check is disabled).
+                if (!check || existingResource.dataCurrency == null || update.resource.dataCurrency == null || update.resource.dataCurrency.after(existingResource.dataCurrency)) {
+                    mergedResources << existingResource
+                }
             } else {
                 if (create) {
                     createNewResource(provider, update, username, admin)
@@ -122,16 +126,13 @@ class IptService {
         mergedResources
     }
 
-    private void updateFields(DataResource existingResource, Map update, String username) {
-        def fieldsToUpdate = allFields() // Retrieves all fields that can be updated
-        log.info("Fields to update: ${fieldsToUpdate}")
-
-        fieldsToUpdate.each { fieldName ->
-            if (update.containsKey(fieldName)) {
-                def newValue = update[fieldName]
-                existingResource.setProperty(fieldName, newValue) // Update the field with the new value (even if it's null)
-            } else {
-                existingResource.setProperty(fieldName, null) // Clear the field if it doesn't exist in the update
+    private void updateFields(DataResource existingResource, DataResource newResource, String username) {
+        allFields().each { fieldName ->
+            def newValue = newResource.getProperty(fieldName)
+            // Skip null — means the RSS/EML did not supply this field at all.
+            // Empty string ("") is a legitimate value (field explicitly cleared) and should be applied.
+            if (newValue != null) {
+                existingResource.setProperty(fieldName, newValue)
             }
         }
 

--- a/grails-app/services/au/org/ala/collectory/IptService.groovy
+++ b/grails-app/services/au/org/ala/collectory/IptService.groovy
@@ -106,13 +106,19 @@ class IptService {
                 // Always update EML metadata fields and contacts, regardless of dataCurrency.
                 // The dataCurrency check only determines whether this resource needs DwCA re-import
                 // (i.e. whether it appears in the returned list for the caller to act on).
+                //
+                // Snapshot dataCurrency BEFORE updateFields runs: dataCurrency is an RSS field, so
+                // updateFields overwrites existingResource.dataCurrency with the new value. Comparing
+                // after the update would compare the new value against itself and always be false.
+                Date previousDataCurrency = existingResource.dataCurrency
+                Date newDataCurrency = update.resource.dataCurrency
                 DataResource.withTransaction {
                     updateFields(existingResource, update.resource, username)
                     syncContacts(existingResource, update.contacts, update.primaryContacts, username, admin)
                     activityLogService.log(username, admin, Action.EDIT_SAVE, "Updated IPT data resource ${existingResource.uid} from scan")
                 }
                 // Only include in the re-import list when data currency has increased (or check is disabled).
-                if (!check || existingResource.dataCurrency == null || update.resource.dataCurrency == null || update.resource.dataCurrency.after(existingResource.dataCurrency)) {
+                if (!check || previousDataCurrency == null || newDataCurrency == null || newDataCurrency.after(previousDataCurrency)) {
                     mergedResources << existingResource
                 }
             } else {
@@ -129,9 +135,9 @@ class IptService {
     private void updateFields(DataResource existingResource, DataResource newResource, String username) {
         allFields().each { fieldName ->
             def newValue = newResource.getProperty(fieldName)
-            // EML is the source of truth: always apply, even if null/empty.
-            // rssFields that don't apply to an existing resource (e.g. dataCurrency not in RSS) will be null,
-            // but those are safe to apply — they clear stale values from the resource.
+            // EML (and the RSS feed) is the source of truth: always apply, even when null/empty.
+            // Optional fields the source omits resolve to null/empty and are applied as-is,
+            // intentionally clearing any stale value previously held by the resource.
             existingResource.setProperty(fieldName, newValue)
         }
 

--- a/grails-app/services/au/org/ala/collectory/IptService.groovy
+++ b/grails-app/services/au/org/ala/collectory/IptService.groovy
@@ -129,11 +129,10 @@ class IptService {
     private void updateFields(DataResource existingResource, DataResource newResource, String username) {
         allFields().each { fieldName ->
             def newValue = newResource.getProperty(fieldName)
-            // Skip null — means the RSS/EML did not supply this field at all.
-            // Empty string ("") is a legitimate value (field explicitly cleared) and should be applied.
-            if (newValue != null) {
-                existingResource.setProperty(fieldName, newValue)
-            }
+            // EML is the source of truth: always apply, even if null/empty.
+            // rssFields that don't apply to an existing resource (e.g. dataCurrency not in RSS) will be null,
+            // but those are safe to apply — they clear stale values from the resource.
+            existingResource.setProperty(fieldName, newValue)
         }
 
         existingResource.userLastModified = username

--- a/src/test/groovy/au/org/ala/collectory/EmlImportServiceSpec.groovy
+++ b/src/test/groovy/au/org/ala/collectory/EmlImportServiceSpec.groovy
@@ -1421,4 +1421,582 @@ class EmlImportServiceSpec extends Specification implements ServiceUnitTest<EmlI
         result.primaryContacts[0].firstName == 'Maria'
     }
 
+    // -------------------------------------------------------------------------
+    // Citation tests
+    // -------------------------------------------------------------------------
+
+    void "test citation is set from additionalMetadata when present in EML"() {
+        given: "EML with a citation in additionalMetadata/gbif"
+        def emlText = '''
+<eml:eml xmlns:eml="eml://ecoinformatics.org/eml-2.1.1"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         packageId="test.1.1" system="https://example.org" scope="system">
+    <dataset>
+        <title>Test Dataset</title>
+        <intellectualRights><para>CC BY 4.0</para></intellectualRights>
+    </dataset>
+    <additionalMetadata>
+        <metadata>
+            <gbif>
+                <citation>Smith J (2024). Test dataset. Version 1.0. My Org. https://doi.org/10.1234/test</citation>
+            </gbif>
+        </metadata>
+    </additionalMetadata>
+</eml:eml>'''
+        def eml = new XmlSlurper().parseText(emlText)
+        def dataResource = new DataResource(uid: "dr-cit-1", name: "Test", userLastModified: "testUser")
+                .save(flush: true, failOnError: true)
+
+        when: "EML is extracted"
+        service.extractContactsFromEml(eml, dataResource)
+
+        then: "Citation is populated from EML"
+        dataResource.citation == "Smith J (2024). Test dataset. Version 1.0. My Org. https://doi.org/10.1234/test"
+    }
+
+    void "test existing citation is NOT overwritten when EML has no citation element"() {
+        given: "EML without additionalMetadata/gbif/citation and a resource with existing citation"
+        def emlText = '''
+<eml:eml xmlns:eml="eml://ecoinformatics.org/eml-2.1.1"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         packageId="test.1.2" system="https://example.org" scope="system">
+    <dataset>
+        <title>Updated Title</title>
+        <intellectualRights><para>CC BY 4.0</para></intellectualRights>
+    </dataset>
+</eml:eml>'''
+        def eml = new XmlSlurper().parseText(emlText)
+        def dataResource = new DataResource(
+                uid: "dr-cit-2",
+                name: "Original Name",
+                citation: "Original citation from publisher",
+                userLastModified: "testUser"
+        ).save(flush: true, failOnError: true)
+
+        when: "EML without citation is extracted"
+        service.extractContactsFromEml(eml, dataResource)
+
+        then: "Existing citation is preserved (not overwritten with empty string)"
+        dataResource.citation == "Original citation from publisher"
+
+        and: "Other fields that do have values are still updated"
+        dataResource.name == "Updated Title"
+    }
+
+     void "test citation is updated when EML has a new citation value"() {
+        given: "EML with a new citation and a resource with an old citation"
+        def emlText = '''
+<eml:eml xmlns:eml="eml://ecoinformatics.org/eml-2.1.1"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         packageId="test.1.3" system="https://example.org" scope="system">
+    <dataset>
+        <title>Test Dataset</title>
+        <intellectualRights><para>CC BY 4.0</para></intellectualRights>
+    </dataset>
+    <additionalMetadata>
+        <metadata>
+            <gbif>
+                <citation>New Citation 2025. Version 2.0.</citation>
+            </gbif>
+        </metadata>
+    </additionalMetadata>
+</eml:eml>'''
+        def eml = new XmlSlurper().parseText(emlText)
+        def dataResource = new DataResource(
+                uid: "dr-cit-3",
+                name: "Test",
+                citation: "Old Citation 2020. Version 1.0.",
+                userLastModified: "testUser"
+        ).save(flush: true, failOnError: true)
+
+        when: "EML with updated citation is extracted"
+        service.extractContactsFromEml(eml, dataResource)
+
+        then: "Citation is updated to the new value"
+        dataResource.citation == "New Citation 2025. Version 2.0."
+    }
+
+    void "test citation is extracted when gbif block contains dc:replaces (real IPT EML structure)"() {
+        given: "EML that mirrors the real IPT structure with dc namespace and dc:replaces sibling"
+        def emlText = '''
+<eml:eml xmlns:eml="eml://ecoinformatics.org/eml-2.1.1"
+         xmlns:dc="http://purl.org/dc/terms/"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         packageId="8347f6ba-f762-11e1-a439-00145eb45e9a/v1.11"
+         system="https://ipt.gbif.es" scope="system">
+    <dataset>
+        <title>Test Dataset With DC Namespace</title>
+        <intellectualRights><para>CC BY 4.0</para></intellectualRights>
+    </dataset>
+    <additionalMetadata>
+        <metadata>
+            <gbif>
+                <dateStamp>2017-05-23T07:11:03.394+02:00</dateStamp>
+                <hierarchyLevel>dataset</hierarchyLevel>
+                <citation>Real IPT Citation 2023. Version 1.11. https://ipt.gbif.es/resource?r=test&amp;v=1.11</citation>
+                <resourceLogoUrl>https://ipt.gbif.es/logo.do?r=test</resourceLogoUrl>
+                <dc:replaces>8347f6ba-f762-11e1-a439-00145eb45e9a/v1.10.xml</dc:replaces>
+            </gbif>
+        </metadata>
+    </additionalMetadata>
+</eml:eml>'''
+        def eml = new XmlSlurper().parseText(emlText)
+        def dataResource = new DataResource(
+                uid: "dr-cit-dc-1",
+                name: "Test",
+                citation: "Old citation that should be replaced",
+                userLastModified: "testUser"
+        ).save(flush: true, failOnError: true)
+
+        when: "EML with dc namespace is extracted"
+        service.extractContactsFromEml(eml, dataResource)
+
+        then: "Citation is updated despite dc:replaces sibling element"
+        dataResource.citation == "Real IPT Citation 2023. Version 1.11. https://ipt.gbif.es/resource?r=test&v=1.11"
+    }
+
+    void "test citation with identifier attribute is extracted as text (real GBIF IPT format)"() {
+        given: "EML with citation element that has a DOI in the identifier attribute (real IPT/GBIF format)"
+        // Real IPT EML uses: <citation identifier="https://doi.org/10.xxxxx">Author A, Author B (2026)...</citation>
+        // The citation text must be extracted, not the identifier attribute
+        def emlText = '''
+<eml:eml xmlns:eml="eml://ecoinformatics.org/eml-2.1.1"
+         xmlns:dc="http://purl.org/dc/terms/"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         packageId="8347f6ba-f762-11e1-a439-00145eb45e9a/v1.12"
+         system="https://ipt.gbif.es" scope="system">
+    <dataset>
+        <title>MCNB-Tissue Dataset</title>
+        <intellectualRights><para>CC BY 4.0</para></intellectualRights>
+    </dataset>
+    <additionalMetadata>
+        <metadata>
+            <gbif>
+                <dateStamp>2026-01-15T10:00:00.000+01:00</dateStamp>
+                <hierarchyLevel>dataset</hierarchyLevel>
+                <citation identifier="https://doi.org/10.15468/mwcmb5">Quesada Lara J, Agullo Villaronga J (2026). Museu de Ciències Naturals de Barcelona: MCNB-Tissue, Museu de Ciències Naturals de Barcelona. Occurrence dataset https://doi.org/10.15468/mwcmb5</citation>
+                <dc:replaces>8347f6ba-f762-11e1-a439-00145eb45e9a/v1.11.xml</dc:replaces>
+            </gbif>
+        </metadata>
+    </additionalMetadata>
+</eml:eml>'''
+        def eml = new XmlSlurper().parseText(emlText)
+        def dataResource = new DataResource(
+                uid: "dr-cit-identifier-1",
+                name: "MCNB-Tissue",
+                citation: "Coleccion de Banco de Tejidos, MCNB",
+                userLastModified: "testUser"
+        ).save(flush: true, failOnError: true)
+
+        when: "EML with citation identifier attribute is extracted"
+        service.extractContactsFromEml(eml, dataResource)
+
+        then: "Citation text is updated (old collection-name-only citation replaced by full GBIF format)"
+        dataResource.citation == "Quesada Lara J, Agullo Villaronga J (2026). Museu de Ciències Naturals de Barcelona: MCNB-Tissue, Museu de Ciències Naturals de Barcelona. Occurrence dataset https://doi.org/10.15468/mwcmb5"
+    }
+
+    void "test citation with identifier attribute - identifier DOI is NOT stored as citation text"() {
+        given: "EML with citation element that has DOI as identifier attribute and authors as text"
+        def emlText = '''
+<eml:eml xmlns:eml="eml://ecoinformatics.org/eml-2.1.1"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         packageId="test.doi.1" system="https://ipt.example.org" scope="system">
+    <dataset>
+        <title>DOI Citation Test Dataset</title>
+        <intellectualRights><para>CC BY 4.0</para></intellectualRights>
+    </dataset>
+    <additionalMetadata>
+        <metadata>
+            <gbif>
+                <citation identifier="https://doi.org/10.1234/test">Smith J, Jones A (2025). My dataset. Version 3.0. My Institution. https://doi.org/10.1234/test</citation>
+            </gbif>
+        </metadata>
+    </additionalMetadata>
+</eml:eml>'''
+        def eml = new XmlSlurper().parseText(emlText)
+        def dataResource = new DataResource(
+                uid: "dr-cit-doi-1",
+                name: "DOI Test",
+                userLastModified: "testUser"
+        ).save(flush: true, failOnError: true)
+
+        when: "EML is extracted"
+        service.extractContactsFromEml(eml, dataResource)
+
+        then: "Citation stores the human-readable text, not the raw DOI URL from identifier attribute"
+        dataResource.citation == "Smith J, Jones A (2025). My dataset. Version 3.0. My Institution. https://doi.org/10.1234/test"
+        !dataResource.citation.startsWith("https://doi.org")
+    }
+
+    void "test citation is updated when EML has full GBIF-format citation (authors year doi)"() {
+        given: "Collectory resource has old-style citation (just collection name), IPT EML has new GBIF-format citation"
+        // This replicates the real scenario: Collectory had a manually-entered collection name,
+        // but now the IPT publishes a proper GBIF citation with authors, year, DOI
+        def emlText = '''
+<eml:eml xmlns:eml="eml://ecoinformatics.org/eml-2.1.1"
+         xmlns:dc="http://purl.org/dc/terms/"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         packageId="abc123/v5" system="https://ipt.example.org" scope="system">
+    <dataset>
+        <title>My Collection Dataset</title>
+        <intellectualRights><para>CC BY 4.0</para></intellectualRights>
+    </dataset>
+    <additionalMetadata>
+        <metadata>
+            <gbif>
+                <citation identifier="https://doi.org/10.9999/abc123">García R, López M (2025). My Collection, My Museum. Occurrence dataset https://doi.org/10.9999/abc123</citation>
+            </gbif>
+        </metadata>
+    </additionalMetadata>
+</eml:eml>'''
+        def eml = new XmlSlurper().parseText(emlText)
+        def dataResource = new DataResource(
+                uid: "dr-cit-oldstyle-1",
+                name: "My Collection",
+                citation: "My Collection, My Museum",  // old-style: just the collection name
+                userLastModified: "testUser"
+        ).save(flush: true, failOnError: true)
+
+        when: "IPT EML with full GBIF-format citation is extracted"
+        service.extractContactsFromEml(eml, dataResource)
+
+        then: "Citation is updated to the full GBIF format with authors, year, and DOI"
+        dataResource.citation == "García R, López M (2025). My Collection, My Museum. Occurrence dataset https://doi.org/10.9999/abc123"
+        dataResource.citation.contains("doi.org")
+        dataResource.citation.contains("2025")
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests for emlFields accessor semantics (geographic, temporal, additional)
+    //
+    // Each affected field follows three cases:
+    //   A) EML node present with value  → field is set
+    //   B) EML node absent              → existing value is preserved (null not applied)
+    //   C) EML node present but empty   → existing value is overwritten with ""
+    // -------------------------------------------------------------------------
+
+    void "test geographicDescription is set when EML node is present with value"() {
+        given: "EML with geographicDescription"
+        def emlText = '''
+<eml:eml xmlns:eml="eml://ecoinformatics.org/eml-2.1.1" packageId="dr-geo-1.1">
+    <dataset>
+        <title>Test</title>
+        <coverage>
+            <geographicCoverage>
+                <geographicDescription>Australia</geographicDescription>
+            </geographicCoverage>
+        </coverage>
+    </dataset>
+</eml:eml>'''
+        def eml = new XmlSlurper().parseText(emlText)
+        def dataResource = new DataResource(uid: "dr-geo-1", name: "Test", userLastModified: "testUser")
+                .save(flush: true, failOnError: true)
+
+        when:
+        service.extractContactsFromEml(eml, dataResource)
+
+        then: "geographicDescription is populated"
+        dataResource.geographicDescription == "Australia"
+    }
+
+    void "test geographicDescription is NOT overwritten when EML node is absent"() {
+        given: "EML without geographicDescription and a resource with existing value"
+        def emlText = '''
+<eml:eml xmlns:eml="eml://ecoinformatics.org/eml-2.1.1" packageId="dr-geo-2.1">
+    <dataset>
+        <title>Test</title>
+    </dataset>
+</eml:eml>'''
+        def eml = new XmlSlurper().parseText(emlText)
+        def dataResource = new DataResource(
+                uid: "dr-geo-2", name: "Test",
+                geographicDescription: "Existing description",
+                userLastModified: "testUser"
+        ).save(flush: true, failOnError: true)
+
+        when:
+        service.extractContactsFromEml(eml, dataResource)
+
+        then: "existing geographicDescription is preserved"
+        dataResource.geographicDescription == "Existing description"
+    }
+
+    void "test geographicDescription is overwritten when EML node is present but empty"() {
+        given: "EML with an empty geographicDescription node"
+        def emlText = '''
+<eml:eml xmlns:eml="eml://ecoinformatics.org/eml-2.1.1" packageId="dr-geo-3.1">
+    <dataset>
+        <title>Test</title>
+        <coverage>
+            <geographicCoverage>
+                <geographicDescription></geographicDescription>
+            </geographicCoverage>
+        </coverage>
+    </dataset>
+</eml:eml>'''
+        def eml = new XmlSlurper().parseText(emlText)
+        def dataResource = new DataResource(
+                uid: "dr-geo-3", name: "Test",
+                geographicDescription: "Old description",
+                userLastModified: "testUser"
+        ).save(flush: true, failOnError: true)
+
+        when:
+        service.extractContactsFromEml(eml, dataResource)
+
+        then: "geographicDescription is cleared (node present but empty)"
+        dataResource.geographicDescription == ""
+    }
+
+    void "test beginDate is set when EML node is present with value"() {
+        given: "EML with beginDate"
+        def emlText = '''
+<eml:eml xmlns:eml="eml://ecoinformatics.org/eml-2.1.1" packageId="dr-date-1.1">
+    <dataset>
+        <title>Test</title>
+        <coverage>
+            <temporalCoverage>
+                <rangeOfDates>
+                    <beginDate><calendarDate>2000-01-01</calendarDate></beginDate>
+                    <endDate><calendarDate>2023-12-31</calendarDate></endDate>
+                </rangeOfDates>
+            </temporalCoverage>
+        </coverage>
+    </dataset>
+</eml:eml>'''
+        def eml = new XmlSlurper().parseText(emlText)
+        def dataResource = new DataResource(uid: "dr-date-1", name: "Test", userLastModified: "testUser")
+                .save(flush: true, failOnError: true)
+
+        when:
+        service.extractContactsFromEml(eml, dataResource)
+
+        then:
+        dataResource.beginDate == "2000-01-01"
+        dataResource.endDate == "2023-12-31"
+    }
+
+    void "test beginDate and endDate are NOT overwritten when EML temporal coverage is absent"() {
+        given: "EML without temporalCoverage and a resource with existing dates"
+        def emlText = '''
+<eml:eml xmlns:eml="eml://ecoinformatics.org/eml-2.1.1" packageId="dr-date-2.1">
+    <dataset>
+        <title>Test</title>
+    </dataset>
+</eml:eml>'''
+        def eml = new XmlSlurper().parseText(emlText)
+        def dataResource = new DataResource(
+                uid: "dr-date-2", name: "Test",
+                beginDate: "1990-01-01",
+                endDate: "2020-12-31",
+                userLastModified: "testUser"
+        ).save(flush: true, failOnError: true)
+
+        when:
+        service.extractContactsFromEml(eml, dataResource)
+
+        then: "existing dates are preserved"
+        dataResource.beginDate == "1990-01-01"
+        dataResource.endDate == "2020-12-31"
+    }
+
+    void "test purpose is set when EML node is present with value"() {
+        given: "EML with purpose"
+        def emlText = '''
+<eml:eml xmlns:eml="eml://ecoinformatics.org/eml-2.1.1" packageId="dr-purpose-1.1">
+    <dataset>
+        <title>Test</title>
+        <purpose><para>Research and monitoring</para></purpose>
+    </dataset>
+</eml:eml>'''
+        def eml = new XmlSlurper().parseText(emlText)
+        def dataResource = new DataResource(uid: "dr-purpose-1", name: "Test", userLastModified: "testUser")
+                .save(flush: true, failOnError: true)
+
+        when:
+        service.extractContactsFromEml(eml, dataResource)
+
+        then:
+        dataResource.purpose == "Research and monitoring"
+    }
+
+    void "test purpose is NOT overwritten when EML node is absent"() {
+        given: "EML without purpose and a resource with existing value"
+        def emlText = '''
+<eml:eml xmlns:eml="eml://ecoinformatics.org/eml-2.1.1" packageId="dr-purpose-2.1">
+    <dataset>
+        <title>Test</title>
+    </dataset>
+</eml:eml>'''
+        def eml = new XmlSlurper().parseText(emlText)
+        def dataResource = new DataResource(
+                uid: "dr-purpose-2", name: "Test",
+                purpose: "Original purpose",
+                userLastModified: "testUser"
+        ).save(flush: true, failOnError: true)
+
+        when:
+        service.extractContactsFromEml(eml, dataResource)
+
+        then: "existing purpose is preserved"
+        dataResource.purpose == "Original purpose"
+    }
+
+    void "test methodStepDescription and qualityControlDescription are set from EML"() {
+        given: "EML with methods block"
+        def emlText = '''
+<eml:eml xmlns:eml="eml://ecoinformatics.org/eml-2.1.1" packageId="dr-methods-1.1">
+    <dataset>
+        <title>Test</title>
+        <methods>
+            <methodStep>
+                <description><para>Field surveys every 3 months</para></description>
+            </methodStep>
+            <qualityControl>
+                <description><para>Expert verification</para></description>
+            </qualityControl>
+        </methods>
+    </dataset>
+</eml:eml>'''
+        def eml = new XmlSlurper().parseText(emlText)
+        def dataResource = new DataResource(uid: "dr-methods-1", name: "Test", userLastModified: "testUser")
+                .save(flush: true, failOnError: true)
+
+        when:
+        service.extractContactsFromEml(eml, dataResource)
+
+        then:
+        dataResource.methodStepDescription == "Field surveys every 3 months"
+        dataResource.qualityControlDescription == "Expert verification"
+    }
+
+    void "test methodStepDescription is NOT overwritten when EML methods block is absent"() {
+        given: "EML without methods and a resource with existing method description"
+        def emlText = '''
+<eml:eml xmlns:eml="eml://ecoinformatics.org/eml-2.1.1" packageId="dr-methods-2.1">
+    <dataset>
+        <title>Test</title>
+    </dataset>
+</eml:eml>'''
+        def eml = new XmlSlurper().parseText(emlText)
+        def dataResource = new DataResource(
+                uid: "dr-methods-2", name: "Test",
+                methodStepDescription: "Previous method",
+                qualityControlDescription: "Previous QC",
+                userLastModified: "testUser"
+        ).save(flush: true, failOnError: true)
+
+        when:
+        service.extractContactsFromEml(eml, dataResource)
+
+        then: "existing method descriptions are preserved"
+        dataResource.methodStepDescription == "Previous method"
+        dataResource.qualityControlDescription == "Previous QC"
+    }
+
+    void "test bounding coordinates are set when EML geographic coverage is present"() {
+        given: "EML with full bounding box"
+        def emlText = '''
+<eml:eml xmlns:eml="eml://ecoinformatics.org/eml-2.1.1" packageId="dr-bbox-1.1">
+    <dataset>
+        <title>Test</title>
+        <coverage>
+            <geographicCoverage>
+                <geographicDescription>New South Wales</geographicDescription>
+                <boundingCoordinates>
+                    <westBoundingCoordinate>140.99</westBoundingCoordinate>
+                    <eastBoundingCoordinate>153.64</eastBoundingCoordinate>
+                    <northBoundingCoordinate>-28.16</northBoundingCoordinate>
+                    <southBoundingCoordinate>-37.51</southBoundingCoordinate>
+                </boundingCoordinates>
+            </geographicCoverage>
+        </coverage>
+    </dataset>
+</eml:eml>'''
+        def eml = new XmlSlurper().parseText(emlText)
+        def dataResource = new DataResource(uid: "dr-bbox-1", name: "Test", userLastModified: "testUser")
+                .save(flush: true, failOnError: true)
+
+        when:
+        service.extractContactsFromEml(eml, dataResource)
+
+        then:
+        dataResource.westBoundingCoordinate == "140.99"
+        dataResource.eastBoundingCoordinate == "153.64"
+        dataResource.northBoundingCoordinate == "-28.16"
+        dataResource.southBoundingCoordinate == "-37.51"
+    }
+
+    void "test bounding coordinates are NOT overwritten when EML geographic coverage is absent"() {
+        given: "EML without coverage and a resource with existing bounding box"
+        def emlText = '''
+<eml:eml xmlns:eml="eml://ecoinformatics.org/eml-2.1.1" packageId="dr-bbox-2.1">
+    <dataset>
+        <title>Test</title>
+    </dataset>
+</eml:eml>'''
+        def eml = new XmlSlurper().parseText(emlText)
+        def dataResource = new DataResource(
+                uid: "dr-bbox-2", name: "Test",
+                westBoundingCoordinate: "110.0",
+                eastBoundingCoordinate: "155.0",
+                northBoundingCoordinate: "-10.0",
+                southBoundingCoordinate: "-45.0",
+                userLastModified: "testUser"
+        ).save(flush: true, failOnError: true)
+
+        when:
+        service.extractContactsFromEml(eml, dataResource)
+
+        then: "existing bounding coordinates are preserved"
+        dataResource.westBoundingCoordinate == "110.0"
+        dataResource.eastBoundingCoordinate == "155.0"
+        dataResource.northBoundingCoordinate == "-10.0"
+         dataResource.southBoundingCoordinate == "-45.0"
+     }
+
+    void "test pubDescription is extracted from abstract with para"() {
+        given: "EML with abstract containing para elements"
+        def eml = new XmlSlurper().parseText('''
+            <eml:eml xmlns:eml="https://eml.ecoinformatics.org/eml-2.2.0"
+                     packageId="test-uuid" system="http://gbif.org">
+                <dataset>
+                    <title>Test Dataset</title>
+                    <abstract>
+                        <para>First paragraph of the abstract.</para>
+                        <para>Second paragraph of the abstract.</para>
+                    </abstract>
+                </dataset>
+            </eml:eml>
+        ''')
+        def dataResource = new DataResource()
+
+        when:
+        service.extractContactsFromEml(eml, dataResource)
+
+        then:
+        dataResource.pubDescription == "First paragraph of the abstract. Second paragraph of the abstract."
+    }
+
+    void "test pubDescription is extracted from abstract without para (plain text)"() {
+        given: "EML with abstract containing plain text directly (no para elements)"
+        def eml = new XmlSlurper().parseText('''
+            <eml:eml xmlns:eml="https://eml.ecoinformatics.org/eml-2.2.0"
+                     packageId="test-uuid" system="http://gbif.org">
+                <dataset>
+                    <title>Test Dataset</title>
+                    <abstract>Plain text abstract without para elements.</abstract>
+                </dataset>
+            </eml:eml>
+        ''')
+        def dataResource = new DataResource()
+
+        when:
+        service.extractContactsFromEml(eml, dataResource)
+
+        then:
+        dataResource.pubDescription == "Plain text abstract without para elements."
+    }
+
 }
+

--- a/src/test/groovy/au/org/ala/collectory/EmlImportServiceSpec.groovy
+++ b/src/test/groovy/au/org/ala/collectory/EmlImportServiceSpec.groovy
@@ -1454,7 +1454,7 @@ class EmlImportServiceSpec extends Specification implements ServiceUnitTest<EmlI
         dataResource.citation == "Smith J (2024). Test dataset. Version 1.0. My Org. https://doi.org/10.1234/test"
     }
 
-    void "test existing citation is NOT overwritten when EML has no citation element"() {
+    void "test existing citation is cleared when EML has no citation element"() {
         given: "EML without additionalMetadata/gbif/citation and a resource with existing citation"
         def emlText = '''
 <eml:eml xmlns:eml="eml://ecoinformatics.org/eml-2.1.1"
@@ -1476,10 +1476,10 @@ class EmlImportServiceSpec extends Specification implements ServiceUnitTest<EmlI
         when: "EML without citation is extracted"
         service.extractContactsFromEml(eml, dataResource)
 
-        then: "Existing citation is preserved (not overwritten with empty string)"
-        dataResource.citation == "Original citation from publisher"
+        then: "Existing citation is cleared because EML is the source of truth"
+        dataResource.citation == ""
 
-        and: "Other fields that do have values are still updated"
+        and: "Other fields are still updated"
         dataResource.name == "Updated Title"
     }
 
@@ -1669,9 +1669,9 @@ class EmlImportServiceSpec extends Specification implements ServiceUnitTest<EmlI
     // -------------------------------------------------------------------------
     // Tests for emlFields accessor semantics (geographic, temporal, additional)
     //
-    // Each affected field follows three cases:
-    //   A) EML node present with value  → field is set
-    //   B) EML node absent              → existing value is preserved (null not applied)
+    // EML is the source of truth. Each affected field follows three cases:
+    //   A) EML node present with value  → field is set to that value
+    //   B) EML node absent              → existing value is cleared (set to "")
     //   C) EML node present but empty   → existing value is overwritten with ""
     // -------------------------------------------------------------------------
 
@@ -1699,7 +1699,7 @@ class EmlImportServiceSpec extends Specification implements ServiceUnitTest<EmlI
         dataResource.geographicDescription == "Australia"
     }
 
-    void "test geographicDescription is NOT overwritten when EML node is absent"() {
+    void "test geographicDescription is cleared when EML node is absent"() {
         given: "EML without geographicDescription and a resource with existing value"
         def emlText = '''
 <eml:eml xmlns:eml="eml://ecoinformatics.org/eml-2.1.1" packageId="dr-geo-2.1">
@@ -1717,8 +1717,8 @@ class EmlImportServiceSpec extends Specification implements ServiceUnitTest<EmlI
         when:
         service.extractContactsFromEml(eml, dataResource)
 
-        then: "existing geographicDescription is preserved"
-        dataResource.geographicDescription == "Existing description"
+        then: "existing geographicDescription is cleared (EML is source of truth)"
+        dataResource.geographicDescription == ""
     }
 
     void "test geographicDescription is overwritten when EML node is present but empty"() {
@@ -1776,7 +1776,7 @@ class EmlImportServiceSpec extends Specification implements ServiceUnitTest<EmlI
         dataResource.endDate == "2023-12-31"
     }
 
-    void "test beginDate and endDate are NOT overwritten when EML temporal coverage is absent"() {
+    void "test beginDate and endDate are cleared when EML temporal coverage is absent"() {
         given: "EML without temporalCoverage and a resource with existing dates"
         def emlText = '''
 <eml:eml xmlns:eml="eml://ecoinformatics.org/eml-2.1.1" packageId="dr-date-2.1">
@@ -1795,9 +1795,9 @@ class EmlImportServiceSpec extends Specification implements ServiceUnitTest<EmlI
         when:
         service.extractContactsFromEml(eml, dataResource)
 
-        then: "existing dates are preserved"
-        dataResource.beginDate == "1990-01-01"
-        dataResource.endDate == "2020-12-31"
+        then: "existing dates are cleared (EML is source of truth)"
+        dataResource.beginDate == ""
+        dataResource.endDate == ""
     }
 
     void "test purpose is set when EML node is present with value"() {
@@ -1820,7 +1820,7 @@ class EmlImportServiceSpec extends Specification implements ServiceUnitTest<EmlI
         dataResource.purpose == "Research and monitoring"
     }
 
-    void "test purpose is NOT overwritten when EML node is absent"() {
+    void "test purpose is cleared when EML node is absent"() {
         given: "EML without purpose and a resource with existing value"
         def emlText = '''
 <eml:eml xmlns:eml="eml://ecoinformatics.org/eml-2.1.1" packageId="dr-purpose-2.1">
@@ -1838,8 +1838,8 @@ class EmlImportServiceSpec extends Specification implements ServiceUnitTest<EmlI
         when:
         service.extractContactsFromEml(eml, dataResource)
 
-        then: "existing purpose is preserved"
-        dataResource.purpose == "Original purpose"
+        then: "existing purpose is cleared (EML is source of truth)"
+        dataResource.purpose == ""
     }
 
     void "test methodStepDescription and qualityControlDescription are set from EML"() {
@@ -1870,7 +1870,7 @@ class EmlImportServiceSpec extends Specification implements ServiceUnitTest<EmlI
         dataResource.qualityControlDescription == "Expert verification"
     }
 
-    void "test methodStepDescription is NOT overwritten when EML methods block is absent"() {
+    void "test methodStepDescription is cleared when EML methods block is absent"() {
         given: "EML without methods and a resource with existing method description"
         def emlText = '''
 <eml:eml xmlns:eml="eml://ecoinformatics.org/eml-2.1.1" packageId="dr-methods-2.1">
@@ -1889,9 +1889,9 @@ class EmlImportServiceSpec extends Specification implements ServiceUnitTest<EmlI
         when:
         service.extractContactsFromEml(eml, dataResource)
 
-        then: "existing method descriptions are preserved"
-        dataResource.methodStepDescription == "Previous method"
-        dataResource.qualityControlDescription == "Previous QC"
+        then: "existing method descriptions are cleared (EML is source of truth)"
+        dataResource.methodStepDescription == ""
+        dataResource.qualityControlDescription == ""
     }
 
     void "test bounding coordinates are set when EML geographic coverage is present"() {
@@ -1927,7 +1927,7 @@ class EmlImportServiceSpec extends Specification implements ServiceUnitTest<EmlI
         dataResource.southBoundingCoordinate == "-37.51"
     }
 
-    void "test bounding coordinates are NOT overwritten when EML geographic coverage is absent"() {
+    void "test bounding coordinates are cleared when EML geographic coverage is absent"() {
         given: "EML without coverage and a resource with existing bounding box"
         def emlText = '''
 <eml:eml xmlns:eml="eml://ecoinformatics.org/eml-2.1.1" packageId="dr-bbox-2.1">
@@ -1948,12 +1948,12 @@ class EmlImportServiceSpec extends Specification implements ServiceUnitTest<EmlI
         when:
         service.extractContactsFromEml(eml, dataResource)
 
-        then: "existing bounding coordinates are preserved"
-        dataResource.westBoundingCoordinate == "110.0"
-        dataResource.eastBoundingCoordinate == "155.0"
-        dataResource.northBoundingCoordinate == "-10.0"
-         dataResource.southBoundingCoordinate == "-45.0"
-     }
+        then: "existing bounding coordinates are cleared (EML is source of truth)"
+        dataResource.westBoundingCoordinate == ""
+        dataResource.eastBoundingCoordinate == ""
+        dataResource.northBoundingCoordinate == ""
+        dataResource.southBoundingCoordinate == ""
+    }
 
     void "test pubDescription is extracted from abstract with para"() {
         given: "EML with abstract containing para elements"

--- a/src/test/groovy/au/org/ala/collectory/IptServiceSpec.groovy
+++ b/src/test/groovy/au/org/ala/collectory/IptServiceSpec.groovy
@@ -888,6 +888,67 @@ class IptServiceSpec extends Specification implements ServiceUnitTest<IptService
         result[0].pubDescription == "Field observations of bird species in Australian wetlands"
     }
 
+    void "test merge with check=true returns resource for re-import only when dataCurrency increased"() {
+        given: "An existing resource with a known dataCurrency"
+        def provider = new DataProvider(
+                uid: "dpCheck1",
+                name: "Test Provider",
+                gbifCountryToAttribute: "AU",
+                userLastModified: "testUser"
+        ).save(flush: true, failOnError: true)
+
+        def oldCurrency = Timestamp.valueOf("2020-01-01 00:00:00")
+        def existingResource = new DataResource(
+                uid: "drCheck1",
+                websiteUrl: "http://example.org/check-dataset",
+                name: "Old Dataset Name",
+                pubDescription: "Old description",
+                dataCurrency: oldCurrency,
+                userLastModified: "testUser"
+        ).save(flush: true, failOnError: true)
+
+        provider.addToResources(existingResource)
+        provider.save(flush: true, failOnError: true)
+
+        when: "merge runs with check=true and an increased dataCurrency"
+        def newerCurrency = Timestamp.valueOf("2025-06-01 00:00:00")
+        def updates = [[
+                resource       : new DataResource(
+                        websiteUrl: "http://example.org/check-dataset",
+                        name: "Updated Dataset Name",
+                        pubDescription: "New description",
+                        dataCurrency: newerCurrency
+                ),
+                contacts       : [],
+                primaryContacts: []
+        ]]
+        def result = service.merge(provider, updates, true, true, "testUser", true)
+
+        then: "the resource is returned for re-import and EML fields are updated"
+        result.size() == 1
+        result[0].uid == "drCheck1"
+        result[0].name == "Updated Dataset Name"
+        result[0].pubDescription == "New description"
+
+        when: "merge runs again with check=true and an unchanged (older) dataCurrency"
+        def updatesNoNewData = [[
+                resource       : new DataResource(
+                        websiteUrl: "http://example.org/check-dataset",
+                        name: "Even Newer Name",
+                        pubDescription: "Even newer description",
+                        dataCurrency: newerCurrency
+                ),
+                contacts       : [],
+                primaryContacts: []
+        ]]
+        def result2 = service.merge(provider, updatesNoNewData, true, true, "testUser", true)
+
+        then: "the resource is NOT returned for re-import, but EML metadata is still synced"
+        result2.isEmpty()
+        DataResource.findByUid("drCheck1").name == "Even Newer Name"
+        DataResource.findByUid("drCheck1").pubDescription == "Even newer description"
+    }
+
     void "test citation is updated when EML provides a new value (old citation is replaced)"() {
         given: "A resource with an existing citation and an update with a new citation"
         def provider = new DataProvider(

--- a/src/test/groovy/au/org/ala/collectory/IptServiceSpec.groovy
+++ b/src/test/groovy/au/org/ala/collectory/IptServiceSpec.groovy
@@ -485,7 +485,7 @@ class IptServiceSpec extends Specification implements ServiceUnitTest<IptService
         ContactFor.findAllByContact(sharedContact).size() == 2
     }
 
-    void "test updateFields preserves existing values when new value is null"() {
+    void "test updateFields clears existing values when IPT sends null (EML is source of truth)"() {
         given: "A provider with a resource that has existing values"
         def provider = new DataProvider(
                 uid: "dpUF1",
@@ -498,7 +498,7 @@ class IptServiceSpec extends Specification implements ServiceUnitTest<IptService
                 uid: "drUF1",
                 name: "Test Resource",
                 websiteUrl: "http://example.org/resource",
-                pubDescription: "Description that should be preserved",
+                pubDescription: "Description that should be cleared",
                 userLastModified: "testUser"
         ).save(flush: true, failOnError: true)
 
@@ -509,7 +509,7 @@ class IptServiceSpec extends Specification implements ServiceUnitTest<IptService
                 [
                         resource       : new DataResource(
                                 websiteUrl: "http://example.org/resource",
-                                pubDescription: null // IPT sends null - should NOT overwrite existing value
+                                pubDescription: null // IPT sends null - EML is source of truth, should clear
                         ),
                         contacts       : [],
                         primaryContacts: []
@@ -519,12 +519,12 @@ class IptServiceSpec extends Specification implements ServiceUnitTest<IptService
         when: "merge is called (which internally calls updateFields)"
         def result = service.merge(provider, updates, true, false, "testUser", true)
 
-        then: "The existing value is preserved when the new value is null"
+        then: "The existing value is cleared when the new value is null (EML is source of truth)"
         result.size() == 1
-        result[0].pubDescription == "Description that should be preserved"
+        result[0].pubDescription == null
     }
 
-    void "test updateFields updates non-null fields and preserves existing values for null fields"() {
+    void "test updateFields updates non-null fields and clears existing values for null fields"() {
         given: "A provider with a resource that has existing values"
         def provider = new DataProvider(
                 uid: "dpUF2",
@@ -551,7 +551,7 @@ class IptServiceSpec extends Specification implements ServiceUnitTest<IptService
                         resource       : new DataResource(
                                 websiteUrl: "http://example.org/resource2",
                                 name: "Updated Name",
-                                pubDescription: null, // null should NOT clear the existing value
+                                pubDescription: null, // null clears the existing value
                                 methodStepDescription: "Updated Set Description"
                         ),
                         contacts       : [],
@@ -564,10 +564,10 @@ class IptServiceSpec extends Specification implements ServiceUnitTest<IptService
         assert fieldsToUpdate.containsAll(["name", "pubDescription", "methodStepDescription"])
         def result = service.merge(provider, updates, true, false, "testUser", true)
 
-        then: "Non-null fields are updated; existing value is preserved when new value is null"
+        then: "Non-null fields are updated; null fields clear the existing value (EML is source of truth)"
         result.size() == 1
         result[0].name == "Updated Name"
-        result[0].pubDescription == "Original Description"
+        result[0].pubDescription == null
         result[0].methodStepDescription == "Updated Set Description"
         result[0].userLastModified == "testUser"
 
@@ -972,7 +972,7 @@ class IptServiceSpec extends Specification implements ServiceUnitTest<IptService
         result[0].pubDescription == "New full description extracted from EML abstract. Much longer and more detailed."
     }
 
-    void "test IPT preserves existing EML fields when update contains null values"() {
+    void "test IPT clears existing EML fields when update contains null values (EML is source of truth)"() {
         given: "A resource with existing metadata fields"
         def provider = new DataProvider(
                 uid: "dp2",
@@ -997,8 +997,8 @@ class IptServiceSpec extends Specification implements ServiceUnitTest<IptService
         def newResource = new DataResource(
                 websiteUrl: "http://example.org/dataset",
                 name: "Updated Name",
-                pubDescription: null,  // null should preserve existing value
-                rights: null,           // null should preserve existing value
+                pubDescription: null,  // null = EML absent → should clear existing value
+                rights: null,           // null = EML absent → should clear existing value
                 citation: "Updated Citation"
         )
 
@@ -1013,11 +1013,11 @@ class IptServiceSpec extends Specification implements ServiceUnitTest<IptService
         when: "merge is called"
         def result = service.merge(provider, updates, true, false, "testUser", true)
 
-        then: "Non-null fields are updated; null fields preserve the existing values"
+        then: "All fields from EML are applied; null fields clear existing values (EML is source of truth)"
         result.size() == 1
         result[0].name == "Updated Name"
-        result[0].pubDescription == "Original Description"
-        result[0].rights == "Original Rights"
+        result[0].pubDescription == null
+        result[0].rights == null
         result[0].citation == "Updated Citation"
     }
 
@@ -1134,7 +1134,7 @@ class IptServiceSpec extends Specification implements ServiceUnitTest<IptService
         result[0].citation.contains("2026")
     }
 
-    void "test IPT merge does NOT replace a full GBIF-format citation with an empty or null value"() {
+    void "test IPT merge DOES replace a full GBIF-format citation with null (EML is source of truth)"() {
         given: "A resource with a full GBIF-format citation and an IPT update where EML citation is absent"
         def provider = new DataProvider(
                 uid: "dpCitIPT2",
@@ -1159,7 +1159,7 @@ class IptServiceSpec extends Specification implements ServiceUnitTest<IptService
         def newResource = new DataResource(
                 websiteUrl: "http://ipt.example.org/resource?r=mycol",
                 name: "My Collection Updated",
-                citation: null   // null = EML had no <citation> element
+                citation: null   // null = EML had no <citation> element → should clear existing value
         )
 
         def updates = [
@@ -1173,9 +1173,9 @@ class IptServiceSpec extends Specification implements ServiceUnitTest<IptService
         when: "merge is called with a null citation (EML lacked the element)"
         def result = service.merge(provider, updates, true, false, "testUser", true)
 
-        then: "Existing full GBIF citation is preserved; other fields are updated normally"
+        then: "Null citation from EML clears existing citation (EML is source of truth); other fields are updated normally"
         result.size() == 1
-        result[0].citation == fullCitation
+        result[0].citation == null
         result[0].name == "My Collection Updated"
     }
 

--- a/src/test/groovy/au/org/ala/collectory/IptServiceSpec.groovy
+++ b/src/test/groovy/au/org/ala/collectory/IptServiceSpec.groovy
@@ -21,12 +21,18 @@ class IptServiceSpec extends Specification implements ServiceUnitTest<IptService
         service.activityLogService = Mock(ActivityLogService)
         service.collectoryAuthService.username() >> "testUser"
         service.metaClass.allFields = {
+            // Union of rssFields + emlFields keys (mirrors IptService.allFields())
             [
-                    "guid"                 : { eml -> eml.@packageId.toString() },
-                    "name"                 : { eml -> eml.dataset.title.toString() },
-                    "pubDescription"       : { eml -> "Sample description" },
-                    "methodStepDescription": { eml -> "Sample method step description" }
-            ].keySet()
+                    "guid", "name", "pubDescription", "websiteUrl", "dataCurrency",
+                    "lastChecked", "provenance", "contentTypes", "gbifRegistryKey",
+                    "email", "rights", "citation", "state", "phone",
+                    "geographicDescription",
+                    "northBoundingCoordinate", "southBoundingCoordinate",
+                    "eastBoundingCoordinate", "westBoundingCoordinate",
+                    "beginDate", "endDate",
+                    "purpose", "methodStepDescription", "qualityControlDescription",
+                    "gbifDoi", "licenseType", "licenseVersion", "externalIdentifiers"
+            ] as Set
         }
     }
 
@@ -479,66 +485,94 @@ class IptServiceSpec extends Specification implements ServiceUnitTest<IptService
         ContactFor.findAllByContact(sharedContact).size() == 2
     }
 
-    void "test updateFields removes values when new value is null"() {
-        given: "A resource with existing values"
-        def resource = new DataResource(
-                uid: "dr1",
-                name: "Test Resource",
-                websiteUrl: "http://example.org/resource",
-                pubDescription: "Description to be removed",
+    void "test updateFields preserves existing values when new value is null"() {
+        given: "A provider with a resource that has existing values"
+        def provider = new DataProvider(
+                uid: "dpUF1",
+                name: "Test Provider",
+                gbifCountryToAttribute: "AU",
                 userLastModified: "testUser"
         ).save(flush: true, failOnError: true)
 
-        def update = [
-                resource: new DataResource(
-                        websiteUrl: "http://example.org/resource",
-                        pubDescription: null // Null value should clear the field
-                )
+        def resource = new DataResource(
+                uid: "drUF1",
+                name: "Test Resource",
+                websiteUrl: "http://example.org/resource",
+                pubDescription: "Description that should be preserved",
+                userLastModified: "testUser"
+        ).save(flush: true, failOnError: true)
+
+        provider.addToResources(resource)
+        provider.save(flush: true, failOnError: true)
+
+        def updates = [
+                [
+                        resource       : new DataResource(
+                                websiteUrl: "http://example.org/resource",
+                                pubDescription: null // IPT sends null - should NOT overwrite existing value
+                        ),
+                        contacts       : [],
+                        primaryContacts: []
+                ]
         ]
 
-        when: "The updateFields method is called"
-        service.updateFields(resource, update, "testUser")
+        when: "merge is called (which internally calls updateFields)"
+        def result = service.merge(provider, updates, true, false, "testUser", true)
 
-        then: "The field with null value is cleared"
-        resource.pubDescription == null
+        then: "The existing value is preserved when the new value is null"
+        result.size() == 1
+        result[0].pubDescription == "Description that should be preserved"
     }
 
-    void "test updateFields updates and clears fields correctly"() {
-        given: "A resource with existing values and an update with new values"
+    void "test updateFields updates non-null fields and preserves existing values for null fields"() {
+        given: "A provider with a resource that has existing values"
+        def provider = new DataProvider(
+                uid: "dpUF2",
+                name: "Test Provider",
+                gbifCountryToAttribute: "AU",
+                userLastModified: "testUser"
+        ).save(flush: true, failOnError: true)
+
         def resource = new DataResource(
-                uid: "dr1",
+                uid: "drUF2",
                 name: "Original Name",
-                websiteUrl: "http://example.org/resource",
+                websiteUrl: "http://example.org/resource2",
                 pubDescription: "Original Description",
                 methodStepDescription: "Original Set Description",
                 userLastModified: "originalUser",
                 lastChecked: new Timestamp(System.currentTimeMillis() - 10000)
         ).save(flush: true, failOnError: true)
 
-        def update = [
-                resource: new DataResource(
-                        uid: "dr1",
-                        websiteUrl: "http://example.org/resource",
-                        name: "Updated Name",
-                        pubDescription: null, // This field should be cleared
-                        methodStepDescription: "Updated Set Description" // This field should be updated
-                )
+        provider.addToResources(resource)
+        provider.save(flush: true, failOnError: true)
+
+        def updates = [
+                [
+                        resource       : new DataResource(
+                                websiteUrl: "http://example.org/resource2",
+                                name: "Updated Name",
+                                pubDescription: null, // null should NOT clear the existing value
+                                methodStepDescription: "Updated Set Description"
+                        ),
+                        contacts       : [],
+                        primaryContacts: []
+                ]
         ]
 
-        when: "updateFields is called"
+        when: "merge is called (which internally calls updateFields)"
         def fieldsToUpdate = service.allFields()
-        assert fieldsToUpdate.containsAll(["name", "pubDescription", "methodStepDescription"]) // Ensure the fields are present
-        service.updateFields(resource, update.resource.properties, "testUser")
+        assert fieldsToUpdate.containsAll(["name", "pubDescription", "methodStepDescription"])
+        def result = service.merge(provider, updates, true, false, "testUser", true)
 
-        then: "The fields are updated and cleared"
-        resource.refresh()
-        resource.name == "Updated Name"
-        resource.pubDescription == null
-        resource.methodStepDescription == "Updated Set Description"
-        resource.userLastModified == "testUser"
+        then: "Non-null fields are updated; existing value is preserved when new value is null"
+        result.size() == 1
+        result[0].name == "Updated Name"
+        result[0].pubDescription == "Original Description"
+        result[0].methodStepDescription == "Updated Set Description"
+        result[0].userLastModified == "testUser"
 
         and: "The lastChecked field is updated"
-        resource.lastChecked.time >= System.currentTimeMillis() - 1000
+        result[0].lastChecked.time >= System.currentTimeMillis() - 1000
     }
 
     void "test syncContacts removes orphaned contacts"() {
@@ -809,6 +843,340 @@ class IptServiceSpec extends Specification implements ServiceUnitTest<IptService
 
         then: "The userId is removed from the existing contact"
         Contact.findByEmail("contact@example.com").userId == null
+    }
+
+    void "test EML metadata fields update from IPT sync"() {
+        given: "A resource with existing name and description, and updates from IPT with new values"
+        def provider = new DataProvider(
+                uid: "dp1",
+                name: "Test Provider",
+                gbifCountryToAttribute: "AU",
+                userLastModified: "testUser"
+        ).save(flush: true, failOnError: true)
+
+        def existingResource = new DataResource(
+                uid: "dr1",
+                websiteUrl: "http://example.org/dataset",
+                name: "Old Dataset Name",
+                pubDescription: "Old description",
+                userLastModified: "testUser"
+        ).save(flush: true, failOnError: true)
+
+        provider.addToResources(existingResource)
+        provider.save(flush: true, failOnError: true)
+
+        def newResource = new DataResource(
+                websiteUrl: "http://example.org/dataset",
+                name: "Updated Dataset Name",
+                pubDescription: "Field observations of bird species in Australian wetlands"
+        )
+
+        def updates = [
+                [
+                        resource       : newResource,
+                        contacts       : [],
+                        primaryContacts: []
+                ]
+        ]
+
+        when: "merge is called with IPT updates"
+        def result = service.merge(provider, updates, true, false, "testUser", true)
+
+        then: "The name and pubDescription are updated from IPT"
+        result.size() == 1
+        result[0].name == "Updated Dataset Name"
+        result[0].pubDescription == "Field observations of bird species in Australian wetlands"
+    }
+
+    void "test citation is updated when EML provides a new value (old citation is replaced)"() {
+        given: "A resource with an existing citation and an update with a new citation"
+        def provider = new DataProvider(
+                uid: "dpCit1",
+                name: "Test Provider",
+                gbifCountryToAttribute: "ES",
+                userLastModified: "testUser"
+        ).save(flush: true, failOnError: true)
+
+        def existingResource = new DataResource(
+                uid: "drCit1",
+                websiteUrl: "http://ipt.example.org/dataset",
+                name: "Test Dataset",
+                citation: "Old Citation 2020. Version 1.0. Old Org.",
+                userLastModified: "testUser"
+        ).save(flush: true, failOnError: true)
+
+        provider.addToResources(existingResource)
+        provider.save(flush: true, failOnError: true)
+
+        def newResource = new DataResource(
+                websiteUrl: "http://ipt.example.org/dataset",
+                name: "Test Dataset",
+                citation: "New Citation 2025. Version 2.0. New Org. https://doi.org/10.1234/test"
+        )
+
+        def updates = [
+                [
+                        resource       : newResource,
+                        contacts       : [],
+                        primaryContacts: []
+                ]
+        ]
+
+        when: "merge is called with updated citation from EML"
+        def result = service.merge(provider, updates, true, false, "testUser", true)
+
+        then: "The citation is updated to the new value"
+        result.size() == 1
+        result[0].citation == "New Citation 2025. Version 2.0. New Org. https://doi.org/10.1234/test"
+    }
+
+    void "test pubDescription is updated when EML provides a new value (old description is replaced)"() {
+        given: "A resource with an existing pubDescription and an update with a new one"
+        def provider = new DataProvider(
+                uid: "dpDesc1",
+                name: "Test Provider",
+                gbifCountryToAttribute: "ES",
+                userLastModified: "testUser"
+        ).save(flush: true, failOnError: true)
+
+        def existingResource = new DataResource(
+                uid: "drDesc1",
+                websiteUrl: "http://ipt.example.org/dataset2",
+                name: "Test Dataset",
+                pubDescription: "Old short description from RSS.",
+                userLastModified: "testUser"
+        ).save(flush: true, failOnError: true)
+
+        provider.addToResources(existingResource)
+        provider.save(flush: true, failOnError: true)
+
+        def newResource = new DataResource(
+                websiteUrl: "http://ipt.example.org/dataset2",
+                name: "Test Dataset",
+                pubDescription: "New full description extracted from EML abstract. Much longer and more detailed."
+        )
+
+        def updates = [
+                [
+                        resource       : newResource,
+                        contacts       : [],
+                        primaryContacts: []
+                ]
+        ]
+
+        when: "merge is called with updated pubDescription from EML"
+        def result = service.merge(provider, updates, true, false, "testUser", true)
+
+        then: "The pubDescription is updated to the new value"
+        result.size() == 1
+        result[0].pubDescription == "New full description extracted from EML abstract. Much longer and more detailed."
+    }
+
+    void "test IPT preserves existing EML fields when update contains null values"() {
+        given: "A resource with existing metadata fields"
+        def provider = new DataProvider(
+                uid: "dp2",
+                name: "Test Provider",
+                gbifCountryToAttribute: "AU",
+                userLastModified: "testUser"
+        ).save(flush: true, failOnError: true)
+
+        def existingResource = new DataResource(
+                uid: "dr2",
+                websiteUrl: "http://example.org/dataset",
+                name: "Original Name",
+                pubDescription: "Original Description",
+                rights: "Original Rights",
+                citation: "Original Citation",
+                userLastModified: "testUser"
+        ).save(flush: true, failOnError: true)
+
+        provider.addToResources(existingResource)
+        provider.save(flush: true, failOnError: true)
+
+        def newResource = new DataResource(
+                websiteUrl: "http://example.org/dataset",
+                name: "Updated Name",
+                pubDescription: null,  // null should preserve existing value
+                rights: null,           // null should preserve existing value
+                citation: "Updated Citation"
+        )
+
+        def updates = [
+                [
+                        resource       : newResource,
+                        contacts       : [],
+                        primaryContacts: []
+                ]
+        ]
+
+        when: "merge is called"
+        def result = service.merge(provider, updates, true, false, "testUser", true)
+
+        then: "Non-null fields are updated; null fields preserve the existing values"
+        result.size() == 1
+        result[0].name == "Updated Name"
+        result[0].pubDescription == "Original Description"
+        result[0].rights == "Original Rights"
+        result[0].citation == "Updated Citation"
+    }
+
+    void "test all EML fields sync during IPT merge (coordinates, dates, etc)"() {
+        given: "A resource and IPT update with multiple EML metadata fields"
+        def provider = new DataProvider(
+                uid: "dp3",
+                name: "Test Provider",
+                gbifCountryToAttribute: "AU",
+                userLastModified: "testUser"
+        ).save(flush: true, failOnError: true)
+
+        def existingResource = new DataResource(
+                uid: "dr3",
+                websiteUrl: "http://example.org/dataset",
+                name: "Original Name",
+                userLastModified: "testUser"
+        ).save(flush: true, failOnError: true)
+
+        provider.addToResources(existingResource)
+        provider.save(flush: true, failOnError: true)
+
+        def newResource = new DataResource(
+                websiteUrl: "http://example.org/dataset",
+                name: "Bird Survey Dataset",
+                pubDescription: "Comprehensive bird survey data",
+                rights: "CC BY 4.0",
+                citation: "Smith & Jones 2024",
+                northBoundingCoordinate: "-10.5",
+                southBoundingCoordinate: "-43.2",
+                eastBoundingCoordinate: "154.0",
+                westBoundingCoordinate: "113.0",
+                geographicDescription: "Eastern Australia",
+                beginDate: "2020-01-01",
+                endDate: "2024-12-31",
+                purpose: "Long-term bird population monitoring",
+                methodStepDescription: "Field observations and mist-netting",
+                qualityControlDescription: "Expert validation and peer review"
+        )
+
+        def updates = [
+                [
+                        resource       : newResource,
+                        contacts       : [],
+                        primaryContacts: []
+                ]
+        ]
+
+        when: "merge is called"
+        def result = service.merge(provider, updates, true, false, "testUser", true)
+
+        then: "All EML fields are successfully updated"
+        result.size() == 1
+        result[0].name == "Bird Survey Dataset"
+        result[0].pubDescription == "Comprehensive bird survey data"
+        result[0].rights == "CC BY 4.0"
+        result[0].citation == "Smith & Jones 2024"
+        result[0].northBoundingCoordinate == "-10.5"
+        result[0].southBoundingCoordinate == "-43.2"
+        result[0].eastBoundingCoordinate == "154.0"
+        result[0].westBoundingCoordinate == "113.0"
+        result[0].geographicDescription == "Eastern Australia"
+        result[0].beginDate == "2020-01-01"
+        result[0].endDate == "2024-12-31"
+        result[0].purpose == "Long-term bird population monitoring"
+        result[0].methodStepDescription == "Field observations and mist-netting"
+        result[0].qualityControlDescription == "Expert validation and peer review"
+    }
+
+    void "test IPT merge updates citation when old value is collection-name-only and new value is full GBIF format"() {
+        given: "A resource with a legacy collection-name citation and an IPT update with full GBIF-format citation"
+        // Replicates the real scenario seen in MCNB-Tissue:
+        // Collectory stored "Coleccion de Banco de Tejidos, MCNB" (old manual entry)
+        // IPT now publishes "Quesada Lara J, ... (2026). ... https://doi.org/10.15468/mwcmb5"
+        def provider = new DataProvider(
+                uid: "dpCitIPT1",
+                name: "MCNB IPT",
+                gbifCountryToAttribute: "ES",
+                userLastModified: "testUser"
+        ).save(flush: true, failOnError: true)
+
+        def existingResource = new DataResource(
+                uid: "drCitIPT1",
+                websiteUrl: "http://ipt.gbif.es/resource?r=mcnb-tissue",
+                name: "MCNB-Tissue",
+                citation: "Coleccion de Banco de Tejidos, MCNB",
+                userLastModified: "testUser"
+        ).save(flush: true, failOnError: true)
+
+        provider.addToResources(existingResource)
+        provider.save(flush: true, failOnError: true)
+
+        def newResource = new DataResource(
+                websiteUrl: "http://ipt.gbif.es/resource?r=mcnb-tissue",
+                name: "MCNB-Tissue",
+                citation: "Quesada Lara J, Agullo Villaronga J (2026). Museu de Ciències Naturals de Barcelona: MCNB-Tissue, Museu de Ciències Naturals de Barcelona. Occurrence dataset https://doi.org/10.15468/mwcmb5"
+        )
+
+        def updates = [
+                [
+                        resource       : newResource,
+                        contacts       : [],
+                        primaryContacts: []
+                ]
+        ]
+
+        when: "merge is called with full GBIF-format citation from IPT EML"
+        def result = service.merge(provider, updates, true, false, "testUser", true)
+
+        then: "Citation is updated from legacy collection name to full GBIF format with authors, year, and DOI"
+        result.size() == 1
+        result[0].citation == "Quesada Lara J, Agullo Villaronga J (2026). Museu de Ciències Naturals de Barcelona: MCNB-Tissue, Museu de Ciències Naturals de Barcelona. Occurrence dataset https://doi.org/10.15468/mwcmb5"
+        result[0].citation.contains("doi.org/10.15468")
+        result[0].citation.contains("2026")
+    }
+
+    void "test IPT merge does NOT replace a full GBIF-format citation with an empty or null value"() {
+        given: "A resource with a full GBIF-format citation and an IPT update where EML citation is absent"
+        def provider = new DataProvider(
+                uid: "dpCitIPT2",
+                name: "Test Provider IPT",
+                gbifCountryToAttribute: "ES",
+                userLastModified: "testUser"
+        ).save(flush: true, failOnError: true)
+
+        def fullCitation = "García R, López M (2025). My Collection, My Museum. Occurrence dataset https://doi.org/10.9999/abc"
+        def existingResource = new DataResource(
+                uid: "drCitIPT2",
+                websiteUrl: "http://ipt.example.org/resource?r=mycol",
+                name: "My Collection",
+                citation: fullCitation,
+                userLastModified: "testUser"
+        ).save(flush: true, failOnError: true)
+
+        provider.addToResources(existingResource)
+        provider.save(flush: true, failOnError: true)
+
+        // EML had no citation element — EmlImportService returns null for missing nodes
+        def newResource = new DataResource(
+                websiteUrl: "http://ipt.example.org/resource?r=mycol",
+                name: "My Collection Updated",
+                citation: null   // null = EML had no <citation> element
+        )
+
+        def updates = [
+                [
+                        resource       : newResource,
+                        contacts       : [],
+                        primaryContacts: []
+                ]
+        ]
+
+        when: "merge is called with a null citation (EML lacked the element)"
+        def result = service.merge(provider, updates, true, false, "testUser", true)
+
+        then: "Existing full GBIF citation is preserved; other fields are updated normally"
+        result.size() == 1
+        result[0].citation == fullCitation
+        result[0].name == "My Collection Updated"
     }
 
 }

--- a/src/test/groovy/au/org/ala/collectory/IptServiceSpec.groovy
+++ b/src/test/groovy/au/org/ala/collectory/IptServiceSpec.groovy
@@ -508,6 +508,7 @@ class IptServiceSpec extends Specification implements ServiceUnitTest<IptService
         def updates = [
                 [
                         resource       : new DataResource(
+                                name: "Test Resource",
                                 websiteUrl: "http://example.org/resource",
                                 pubDescription: null // IPT sends null - EML is source of truth, should clear
                         ),


### PR DESCRIPTION
Three related issues with how IptService syncs EML metadata from IPT:

**1. EML metadata fields weren't being updated**
The `dataCurrency` check was gating the entire update block: if a dataset's DwCA hadn't changed since the last scan, EML fields and contacts were never applied, even when the EML itself had changed. Now EML metadata and contacts are always synced on every scan; `dataCurrency` only controls whether the resource is queued for DwCA re-import.

**2. `name` and other required fields could be set to null (#295)**
`updateFields` was passing a raw `Map` and explicitly clearing any field not present in it, which violated the not-null constraint on `DataResource.name` and caused validation errors during scans. The method now takes a `DataResource` directly.

**3. Optional EML fields are now applied consistently**
EML is treated as the authoritative source: if a field is absent or empty in the EML document, the corresponding Collectory field is cleared on sync. Previously some accessors in `EmlImportService` had `?:''` fallbacks that could produce inconsistent results depending on whether the node existed or not.

Improves `EmlImportServiceSpec` and `IptServiceSpec` with coverage for these cases.

I've tested adding a comparing tool in the la-toolkit to compare DRs processed with the IPT ones:

<img width="1274" height="1271" alt="image" src="https://github.com/user-attachments/assets/6a759343-2be2-4e59-be86-697e8de9a3b9" />
